### PR TITLE
Feature/story 2.3 repository governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owner for the entire repository
+
+- @smunyao
+
+# Protect repository governance files
+
+/.github/ @smunyao

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thank you for your interest in contributing to this project.
+
+This repository contains both open-source software and personal portfolio content. Contributions are welcome where they improve the software, accessibility, performance, maintainability or overall quality of the project.
+
+## How to contribute
+
+Please submit changes through a pull request.
+
+A typical contribution should:
+
+1. Fork the repository or create a separate branch where appropriate.
+2. Make the proposed changes.
+3. Run the relevant checks locally.
+4. Submit a pull request explaining what changed and why.
+
+Changes should not be pushed directly to the `main` branch.
+
+## Before submitting
+
+Please make sure that:
+
+- the project builds successfully;
+- existing behaviour has not been unintentionally broken;
+- accessibility is considered where relevant;
+- the change follows the existing structure and design language;
+- unnecessary dependencies are avoided;
+- the pull request is focused on a clear purpose.
+
+For changes to the application, run:
+
+```bash
+npm run lint
+npm run build
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 @smunyao
+Copyright (c) 2026 Kitaka Munyao
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ Planned improvements include:
 
 ---
 
-## Licence
+## Licence and content rights
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+The source code in this repository is licensed under the [MIT License](LICENSE).
+
+Unless otherwise stated, the original editorial and personal content in this repository — including case studies, professional experience, biography, project narratives, written commentary, branding and original imagery — is © 2026 Kitaka Munyao. All rights reserved.
+
+The MIT License applies to the source code and does not grant permission to reproduce, republish or adapt that original editorial or personal content.
+
+Third-party names, trademarks, logos and other assets remain the property of their respective owners.

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -11,8 +11,4 @@ export const site = {
     linkedin: "https://www.linkedin.com/in/sylvester-munyao/",
     github: "https://github.com/smunyao",
   },
-
-  resume: {
-    url: "/resume/sylvester-kitaka-munyao-resume.pdf",
-  },
 };

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -32,10 +32,6 @@ function Contact() {
         <a href={site.social.github} target="_blank" rel="noopener noreferrer">
           GitHub
         </a>
-
-        <a href={site.resume.url} target="_blank" rel="noopener noreferrer">
-          Résumé (PDF)
-        </a>
       </div>
     </section>
   );

--- a/src/sections/Hero.css
+++ b/src/sections/Hero.css
@@ -44,71 +44,18 @@
 .hero-signature {
   margin-bottom: 2.5rem;
 
+  color: var(--color-heading);
+
   font-size: 1rem;
   font-weight: 600;
   line-height: 1.5;
   letter-spacing: -0.02em;
-
-  color: var(--color-heading);
-}
-
-.hero-actions {
-  display: flex;
-  gap: var(--space-sm);
-}
-
-.cta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  padding: 0.8rem 1.2rem;
-
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-
-  font-weight: 600;
-  text-decoration: none;
-
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition),
-    transform var(--transition);
-}
-
-.cta:hover {
-  transform: translateY(-1px);
-}
-
-.cta-primary {
-  background: var(--color-heading);
-  color: var(--color-background);
-  border-color: var(--color-heading);
-}
-
-.cta-primary:hover {
-  opacity: 0.92;
-}
-
-.cta-secondary {
-  background: transparent;
-  color: var(--color-heading);
-}
-
-.cta-secondary:hover {
-  background: var(--accent-bg);
-  border-color: var(--color-accent);
-}
-
-.cta:focus-visible {
-  outline: 3px solid var(--color-accent);
-  outline-offset: 3px;
 }
 
 @media (max-width: 768px) {
   .hero {
     min-height: auto;
+
     padding: 3.5rem var(--space-sm) var(--space-md);
   }
 
@@ -128,11 +75,5 @@
 
     font-size: 1rem;
     line-height: 1.55;
-  }
-
-  .hero-actions {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.75rem;
   }
 }

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -28,14 +28,6 @@ function Hero() {
         <a href="#experience" className="cta cta-primary">
           Explore my experience
         </a>
-        <a
-          href="/resume/sylvester-kitaka-munyao-resume.pdf"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cta cta-secondary"
-        >
-          View résumé (PDF)
-        </a>
       </div>
     </section>
   );

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -23,12 +23,6 @@ function Hero() {
       </p>
 
       <p className="hero-signature">— Kitaka</p>
-
-      <div className="hero-actions">
-        <a href="#experience" className="cta cta-primary">
-          Explore my experience
-        </a>
-      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Improves repository privacy, governance and content protection before continuing with additional public portfolio features.

This change removes the publicly available résumé, strengthens repository ownership and contribution controls, and clarifies the distinction between open-source code and personal portfolio content.

## Changes

- Removed the public résumé and résumé links from the portfolio.
- Removed the résumé from normal Git branch and tag history.
- Removed the redundant "Explore my experience" hero action and its unused styles.
- Added repository ownership through `CODEOWNERS`.
- Added contribution guidelines.
- Clarified that source code is licensed under MIT while original personal and editorial portfolio content remains separately protected.
- Updated the MIT copyright notice.
- Added repository protection through a GitHub ruleset.
- Reviewed collaborator and application access.

## Repository governance

`main` is now protected by a GitHub ruleset that:

- requires changes to be submitted through pull requests;
- prevents deletion of the protected branch;
- blocks force pushes;
- requires pull-request conversations to be resolved before merging.

Mandatory approvals and code-owner approval are intentionally not required while the repository has a single maintainer. Required status checks are deferred until automated CI checks are introduced.

## Verification

- [ ] ESLint passes.
- [ ] Production build succeeds.
- [ ] Public résumé links are no longer present.
- [ ] Former résumé URL no longer serves the résumé.
- [ ] `CODEOWNERS` is recognised by GitHub.
- [ ] `main` protection behaves as expected.
- [ ] README, LICENSE and CONTRIBUTING guidance are consistent.
- [ ] Production deployment verified after merge.

## Follow-up

Historical pull-request refs affected by the résumé history rewrite require separate GitHub-side cleanup.