### PR TITLE
Fix writing page contrast

### DIFF
--- a/src/pages/ArticlePage.css
+++ b/src/pages/ArticlePage.css
@@ -49,7 +49,7 @@
 
   gap: 0.65rem;
 
-  color: color-mix(in srgb, var(--color-text) 65%, transparent);
+  color: var(--color-text);
 
   font-size: 0.78rem;
   font-weight: 500;
@@ -173,7 +173,7 @@
 .article-quote cite {
   font-family: "Geist Variable", system-ui, sans-serif;
 
-  color: color-mix(in srgb, var(--color-text) 65%, transparent);
+  color: var(--color-text);
 
   font-size: 0.8rem;
   font-style: normal;

--- a/src/pages/WritingPage.css
+++ b/src/pages/WritingPage.css
@@ -2,7 +2,7 @@
   max-width: var(--max-width);
 
   margin: 0 auto;
-  padding: 7rem var(--space-md) var(--space-xl);
+  padding: 6rem var(--space-md) var(--space-xl);
 }
 
 .writing-header {
@@ -75,7 +75,7 @@
 
   margin-bottom: 1rem;
 
-  color: color-mix(in srgb, var(--color-text) 65%, transparent);
+  color: var(--color-text);
 
   font-size: 0.78rem;
   font-weight: 500;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -113,8 +113,4 @@
     --shadow:
       rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
   }
-
-  .section-eyebrow {
-    color: #a58b92;
-  }
 }


### PR DESCRIPTION
## Summary

Improve accessibility contrast on the new Writing pages after production Lighthouse audits reported a 95 Accessibility score.

## Changes

- Increase contrast for article metadata.
- Increase contrast for writing-index metadata.
- Increase contrast for article quote citations.
- Remove the dark-mode eyebrow colour override so shared eyebrow styling uses the existing accent token consistently.

## Verification

- [ ] Run ESLint.
- [ ] Run the production build.
- [ ] Verify `/writing`.
- [ ] Verify `/writing/testing-is-information-not-approval`.
- [ ] Re-run Lighthouse after deployment.