### PR TITLE
Document privacy-friendly analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The repository documents the development process through GitHub Issues, feature 
 - GitHub Projects & Issues
 - Cloudflare Pages
 - Cloudflare Registrar
+- Cloudflare Web Analytics
 - Fontsource (Geist)
 
 ---
@@ -66,6 +67,7 @@ The repository documents the development process through GitHub Issues, feature 
 - Reduced-motion support
 - Sticky editorial sidebar
 - Active section tracking
+- Privacy-friendly site analytics
 - Open Graph & Twitter/X metadata
 - Canonical URLs
 - robots.txt & sitemap.xml
@@ -85,7 +87,17 @@ Latest Lighthouse audit (Production):
 | Best Practices | **100** |
 | SEO            | **100** |
 
-> Lighthouse scores are periodically reviewed as the portfolio evolves.
+> Lighthouse scores are periodically reviewed as the portfolio evolves and may vary slightly between routes, devices and individual runs.
+
+---
+
+## Analytics
+
+The portfolio uses **Cloudflare Web Analytics** for lightweight site-usage measurement.
+
+The existing Cloudflare integration records traffic across the portfolio's public routes, including the home page, How I work, case studies, Writing and individual articles.
+
+No additional client-side analytics library or custom event-tracking system has been introduced. Interaction-level tracking will only be considered where the resulting information would be useful enough to justify the additional implementation and maintenance.
 
 ---
 
@@ -136,7 +148,6 @@ Planned improvements include:
 - Dedicated Open Graph images for individual case studies
 - Additional personal engineering projects
 - Potential long-form project pages for larger projects
-- Analytics
 - Continued accessibility improvements
 - Ongoing design refinements
 


### PR DESCRIPTION
## Summary

Document the portfolio's existing Cloudflare Web Analytics implementation and the decisions made during Story 2.7.

## Changes

- Document Cloudflare Web Analytics in the README.
- Document route-level analytics coverage.
- Record the decision not to introduce additional analytics tooling.
- Record the decision to defer custom event tracking.
- Document the current privacy approach.
- Document the role of real-user Core Web Vitals alongside Lighthouse.
- Remove Analytics from the roadmap now that the capability has been reviewed and documented.

## Verification

- [x] Confirm production analytics data is being received.
- [x] Confirm all public routes are tracked.
- [x] Confirm SPA navigation is tracked.
- [x] Confirm localhost traffic is excluded.
- [x] Confirm Cloudflare preview traffic is excluded.
- [x] Review real-user LCP, INP and CLS.
- [x] Confirm no additional performance optimisation is currently warranted.

Shall close #37 