### PR TITLE
feat: add error and empty states

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import ArticlePage from "../pages/ArticlePage";
 import CaseStudyPage from "../pages/CaseStudyPage";
 import HomePage from "../pages/HomePage";
 import HowIWorkPage from "../pages/HowIWorkPage";
+import NotFound from "../pages/NotFound";
 import WritingPage from "../pages/WritingPage";
 import ScrollToTop from "../shared/ScrollToTop";
 
@@ -20,6 +21,8 @@ function App() {
         <Route path="/writing" element={<WritingPage />} />
         <Route path="/writing/:slug" element={<ArticlePage />} />
         <Route path="/case-studies/:slug" element={<CaseStudyPage />} />
+
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </>
   );

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -1,10 +1,11 @@
-import { Link, Navigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 
 import { getArticleBySlug } from "../content/articles";
 import { formatDate } from "../utils/formatDate";
 
 import EditorialPageHeader from "../shared/EditorialPageHeader";
 import Footer from "../shared/Footer";
+import NotFound from "./NotFound";
 import Seo from "../shared/Seo";
 
 import "./ArticlePage.css";
@@ -15,7 +16,7 @@ function ArticlePage() {
   const article = slug ? getArticleBySlug(slug) : undefined;
 
   if (!article) {
-    return <Navigate to="/writing" replace />;
+    return <NotFound variant="article" />;
   }
 
   return (
@@ -119,6 +120,7 @@ function ArticlePage() {
                 <span className="article-back-link-arrow" aria-hidden="true">
                   ←
                 </span>
+
                 <span>Back to writing</span>
               </Link>
             </footer>

--- a/src/pages/CaseStudyPage.tsx
+++ b/src/pages/CaseStudyPage.tsx
@@ -1,9 +1,11 @@
-import { Navigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import { getCaseStudyBySlug } from "../content/caseStudies";
+
 import CaseStudyLayout from "../shared/CaseStudyLayout";
 import EditorialPageHeader from "../shared/EditorialPageHeader";
 import Footer from "../shared/Footer";
+import NotFound from "./NotFound";
 import Seo from "../shared/Seo";
 
 function CaseStudyPage() {
@@ -12,7 +14,7 @@ function CaseStudyPage() {
   const caseStudy = slug ? getCaseStudyBySlug(slug) : undefined;
 
   if (!caseStudy) {
-    return <Navigate to="/" replace />;
+    return <NotFound variant="case-study" />;
   }
 
   return (

--- a/src/pages/NotFound.css
+++ b/src/pages/NotFound.css
@@ -1,0 +1,113 @@
+.not-found-main {
+  display: flex;
+  flex: 1;
+}
+
+.not-found {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  box-sizing: border-box;
+
+  width: 100%;
+  max-width: var(--max-width);
+
+  margin: 0 auto;
+  padding: var(--space-xl) var(--space-md);
+}
+
+.not-found .section-eyebrow {
+  margin-bottom: var(--space-sm);
+}
+
+.not-found h1 {
+  max-width: var(--content-width);
+
+  margin: 0 0 var(--space-md);
+
+  font-size: 48px;
+  font-weight: 400;
+  line-height: 1.08;
+  letter-spacing: -1.2px;
+}
+
+.not-found-description {
+  max-width: var(--content-width);
+
+  margin-bottom: var(--space-md);
+
+  font-size: 1.2rem;
+  line-height: 1.55;
+}
+
+.not-found-recovery-link {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+
+  gap: 0.3rem;
+
+  padding-bottom: 0.2rem;
+
+  border-bottom: 1px solid var(--color-border);
+
+  color: var(--color-heading);
+  text-decoration: none;
+
+  font-size: 0.9rem;
+  font-weight: 500;
+
+  transition: border-color var(--transition);
+}
+
+.not-found-recovery-arrow {
+  color: currentColor;
+
+  transition:
+    color var(--transition),
+    transform var(--transition);
+}
+
+.not-found-recovery-link:hover {
+  color: var(--color-heading);
+
+  border-bottom-color: var(--color-accent);
+}
+
+.not-found-recovery-link:hover .not-found-recovery-arrow {
+  color: var(--color-accent);
+
+  transform: translateX(2px);
+}
+
+.not-found-recovery-link:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 4px;
+
+  border-radius: 4px;
+  border-bottom-color: var(--color-accent);
+}
+
+.not-found-recovery-link:focus-visible .not-found-recovery-arrow {
+  color: var(--color-accent);
+
+  transform: translateX(2px);
+}
+
+@media (max-width: 768px) {
+  .not-found {
+    justify-content: flex-start;
+
+    padding: var(--space-lg) var(--space-sm);
+  }
+
+  .not-found h1 {
+    font-size: 36px;
+    letter-spacing: -0.7px;
+  }
+
+  .not-found-description {
+    font-size: 1rem;
+  }
+}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,95 @@
+import { Link } from "react-router-dom";
+
+import Footer from "../shared/Footer";
+import Seo from "../shared/Seo";
+
+import "./NotFound.css";
+
+type NotFoundVariant = "page" | "article" | "case-study";
+
+interface NotFoundProps {
+  variant?: NotFoundVariant;
+}
+
+interface NotFoundContent {
+  eyebrow: string;
+  title: string;
+  description: string;
+  recoveryTo: string;
+  recoveryLabel: string;
+  seoTitle: string;
+  seoDescription: string;
+}
+
+const notFoundContent: Record<NotFoundVariant, NotFoundContent> = {
+  page: {
+    eyebrow: "Page not found",
+    title: "This page doesn’t exist.",
+    description:
+      "The page may have moved, or the address may be incorrect. You can return to the homepage and continue exploring from there.",
+    recoveryTo: "/",
+    recoveryLabel: "Return to the homepage",
+    seoTitle: "Page not found | Kitaka",
+    seoDescription: "The requested page could not be found.",
+  },
+  article: {
+    eyebrow: "Writing",
+    title: "Article not found.",
+    description:
+      "This article may have moved or is no longer available. You can browse the writing archive to find something else to read.",
+    recoveryTo: "/writing",
+    recoveryLabel: "Browse all writing",
+    seoTitle: "Article not found | Kitaka",
+    seoDescription: "The requested article could not be found.",
+  },
+  "case-study": {
+    eyebrow: "Case studies",
+    title: "Case study not found.",
+    description:
+      "This case study may have moved or is no longer available. You can return to the experience section to explore the available case studies.",
+    recoveryTo: "/#experience",
+    recoveryLabel: "Return to experience",
+    seoTitle: "Case study not found | Kitaka",
+    seoDescription: "The requested case study could not be found.",
+  },
+};
+
+function NotFound({ variant = "page" }: NotFoundProps) {
+  const content = notFoundContent[variant];
+
+  return (
+    <>
+      <Seo
+        title={content.seoTitle}
+        description={content.seoDescription}
+        noIndex
+      />
+
+      <a className="skip-link" href="#main-content">
+        Skip to main content
+      </a>
+
+      <main id="main-content" className="not-found-main" tabIndex={-1}>
+        <section className="not-found" aria-labelledby="not-found-title">
+          <p className="section-eyebrow">{content.eyebrow}</p>
+
+          <h1 id="not-found-title">{content.title}</h1>
+
+          <p className="not-found-description">{content.description}</p>
+
+          <Link className="not-found-recovery-link" to={content.recoveryTo}>
+            <span>{content.recoveryLabel}</span>
+
+            <span className="not-found-recovery-arrow" aria-hidden="true">
+              →
+            </span>
+          </Link>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  );
+}
+
+export default NotFound;

--- a/src/shared/Seo.tsx
+++ b/src/shared/Seo.tsx
@@ -3,9 +3,10 @@ import { Helmet } from "react-helmet-async";
 interface SeoProps {
   title: string;
   description: string;
-  canonical: string;
+  canonical?: string;
   type?: "website" | "article";
   image?: string;
+  noIndex?: boolean;
 }
 
 const SITE_NAME = "Kitaka Munyao";
@@ -18,8 +19,9 @@ function Seo({
   canonical,
   type = "website",
   image = DEFAULT_SOCIAL_IMAGE,
+  noIndex = false,
 }: SeoProps) {
-  const canonicalUrl = `${BASE_URL}${canonical}`;
+  const canonicalUrl = canonical ? `${BASE_URL}${canonical}` : undefined;
   const imageUrl = `${BASE_URL}${image}`;
 
   return (
@@ -30,7 +32,9 @@ function Seo({
 
       <meta name="author" content="Kitaka Munyao" />
 
-      <link rel="canonical" href={canonicalUrl} />
+      {noIndex && <meta name="robots" content="noindex, follow" />}
+
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
 
       <meta property="og:type" content={type} />
 
@@ -40,7 +44,7 @@ function Seo({
 
       <meta property="og:description" content={description} />
 
-      <meta property="og:url" content={canonicalUrl} />
+      {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
 
       <meta property="og:image" content={imageUrl} />
 


### PR DESCRIPTION
## Summary

Introduces deliberate error states for unknown routes and missing content so the portfolio fails gracefully instead of displaying blank pages or silently redirecting visitors.

Closes #56 

## Changes

- Added a reusable Not Found page with contextual variants.
- Added a catch-all route for unknown URLs.
- Added dedicated states for unknown article slugs.
- Added dedicated states for unknown case-study slugs.
- Replaced silent redirects with clear recovery guidance.
- Added contextual recovery links for the homepage, writing archive, and experience section.
- Added responsive styling for the error states.
- Added contextual page titles.
- Added `noindex, follow` metadata to error pages.
- Made canonical metadata optional so invalid URLs are not presented as canonical pages.

## Testing

- [x] Tested an unknown top-level route.
- [x] Tested an unknown article slug.
- [x] Tested an unknown case-study slug.
- [x] Verified recovery links.
- [x] Verified browser Back behaviour.
- [x] Verified keyboard focus styling.
- [x] Reviewed desktop layout.
- [x] Reviewed tablet layout.
- [x] Reviewed mobile layout.
- [x] Confirmed no horizontal overflow.
- [x] Confirmed no browser console errors or warnings.
- [x] Ran ESLint.
- [x] Ran the production build.

## Test URLs

```text
/this-page-does-not-exist
/writing/this-article-does-not-exist
/case-studies/this-case-study-does-not-exist