### PR TITLE
test: add portfolio end-to-end coverage

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,47 @@
+name: Playwright tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+playwright-report/
+test-results/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ Changes should not be pushed directly to the `main` branch.
 Please make sure that:
 
 - the project builds successfully;
+- relevant automated tests pass;
+- appropriate manual or exploratory checks have been completed;
 - existing behaviour has not been unintentionally broken;
 - accessibility is considered where relevant;
 - the change follows the existing structure and design language;
@@ -33,4 +35,17 @@ For changes to the application, run:
 ```bash
 npm run lint
 npm run build
+npm run test:e2e
 ```
+
+The Playwright suite builds and serves the production application
+automatically. On a first-time local setup, install its managed Chromium
+browser with:
+
+```bash
+npx playwright install chromium
+```
+
+See the [test strategy and manual regression guide](docs/testing.md) for test
+scope, debugging commands, selector guidance, manual checks, and preview or
+production verification.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 > A personal portfolio exploring quality engineering, engineering thinking, accessibility, and modern frontend development.
 
 ![React](https://img.shields.io/badge/React-19-61DAFB?logo=react)
-![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript)
 ![Vite](https://img.shields.io/badge/Vite-8-646CFF?logo=vite)
+[![Playwright tests](https://github.com/smunyao/kitaka-portfolio/actions/workflows/playwright.yml/badge.svg)](https://github.com/smunyao/kitaka-portfolio/actions/workflows/playwright.yml)
 ![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)
 
 ## Live site
@@ -48,7 +49,9 @@ The repository documents the development process through GitHub Issues, feature 
 - Vite
 - React Helmet Async
 - Vanilla CSS
+- Playwright
 - Git & GitHub
+- GitHub Actions
 - GitHub Projects & Issues
 - Cloudflare Pages
 - Cloudflare Registrar
@@ -83,7 +86,7 @@ The repository documents the development process through GitHub Issues, feature 
 
 ## Performance
 
-Latest Lighthouse audit (Production):
+Reference Lighthouse audit (Production):
 
 | Metric         |   Score |
 | :------------- | ------: |
@@ -92,7 +95,10 @@ Latest Lighthouse audit (Production):
 | Best Practices | **100** |
 | SEO            | **100** |
 
-> Lighthouse scores are periodically reviewed as the portfolio evolves and may vary slightly between routes, devices and individual runs.
+> Lighthouse scores are periodically reviewed as the portfolio evolves. Scores
+> vary between routes, devices and individual runs, so regressions are assessed
+> using repeated runs and individual performance metrics rather than a single
+> aggregate score.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ npm run preview
 
 ---
 
+## Testing
+
+The portfolio uses Playwright for focused end-to-end coverage of its critical
+routes, navigation, accessibility behaviour, responsive layouts, and error
+states.
+
+Run the automated suite:
+
+```bash
+npm run test:e2e
+```
+
+See the [test strategy and manual regression guide](docs/testing.md) for the
+scope of automation, local and deployed test commands, manual checks,
+exploratory charters, and release criteria.
+
+---
+
 ## Deployment
 
 The site is automatically deployed through **Cloudflare Pages** whenever changes are merged into the `main` branch.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,446 @@
+# Test strategy
+
+## Purpose
+
+This document describes how quality is evaluated for the portfolio, what is
+covered by automation, what remains a deliberate manual activity, and what
+evidence is expected before a change is released.
+
+The strategy is risk-based. Its purpose is not to maximise the number of tests
+or to prove that the site is defect-free. Its purpose is to provide useful,
+repeatable information about the behaviours that matter most to visitors and
+to make regressions visible early enough to act on them.
+
+## Quality risks
+
+The most important product risks are:
+
+1. A visitor cannot reach or navigate the site's core content.
+2. A direct or refreshed route renders a blank, incomplete, or incorrect page.
+3. A keyboard or assistive-technology user cannot understand or operate the
+   site.
+4. Content becomes unreadable or inaccessible at a representative viewport.
+5. Invalid content produces a confusing state or an unrecoverable journey.
+6. metadata causes valid content to be indexed incorrectly or error pages to
+   be indexed unintentionally.
+7. A deployment behaves differently from the locally verified production
+   build.
+8. Performance degrades enough to affect the reading or navigation experience.
+
+These risks determine what is automated, what is checked manually, and what
+must be verified in a deployed environment.
+
+## Testing principles
+
+### Test behaviour, not implementation
+
+Tests should describe outcomes visible to a visitor. Prefer accessible roles,
+names, headings, URLs, and metadata over component names, DOM depth, or CSS
+implementation details.
+
+An assertion should fail because a meaningful behaviour changed, not because a
+harmless refactor rearranged markup.
+
+### Automate repeatable, deterministic checks
+
+Automation is most valuable when a check:
+
+- protects a critical journey;
+- is executed frequently;
+- has an objective result;
+- is expensive or error-prone to repeat manually;
+- can be kept deterministic in an isolated environment.
+
+Visual judgement, editorial quality, and subjective interaction quality remain
+manual unless a specific recurring regression justifies targeted automation.
+
+### Use the lowest sufficient scope
+
+The suite uses browser-level tests because routing, history, focus, responsive
+layout, and metadata are browser behaviours. Tests should not be added at this
+level when a smaller and faster test would provide the same confidence.
+
+The portfolio currently has no separate unit-test layer. Introduce one only
+when application logic becomes complex enough to benefit from isolated tests.
+
+### Treat flaky tests as defects
+
+A flaky test provides ambiguous information and weakens trust in the suite.
+Do not normalise rerunning a failure until it passes. Investigate whether the
+cause is the product, the test, its data, or its environment.
+
+Retries are enabled in CI to preserve diagnostic evidence for an intermittent
+failure. A passing retry does not make the original failure irrelevant.
+
+### Keep tests independent
+
+Each test should establish its own starting state and should not depend on the
+execution order or side effects of another test. Parallel execution must not
+change the result.
+
+## Test levels and ownership
+
+| Layer                   | Purpose                                     | Current approach                   |
+| ----------------------- | ------------------------------------------- | ---------------------------------- |
+| Static analysis         | Detect type and code-quality problems       | TypeScript and ESLint              |
+| Build verification      | Confirm the deployable application compiles | Vite production build              |
+| Browser automation      | Protect critical routes and journeys        | Playwright with Chromium           |
+| Manual regression       | Evaluate usability and visual quality       | Structured checklist               |
+| Exploratory testing     | Discover risks outside known assertions     | Risk-focused charters              |
+| Deployment verification | Detect hosting and environment differences  | Preview and production checks      |
+| Performance and SEO     | Monitor user experience and discoverability | Lighthouse and response inspection |
+
+## Automated coverage
+
+The Playwright suite currently covers:
+
+- direct loading of every public route;
+- the homepage, How I work, Writing, the current article, and every case study;
+- expected primary headings and a single `<h1>` per page;
+- primary navigation and hash navigation;
+- directional links and browser Back and Forward behaviour;
+- links from each experience entry to the correct internal case study;
+- unknown top-level, article, and case-study routes;
+- contextual error headings, metadata, and recovery links;
+- skip-link order and focus movement;
+- visible keyboard focus on critical recovery navigation;
+- reduced-motion behaviour for the homepage hero;
+- horizontal overflow at representative viewports.
+
+The suite does not request external company websites. External availability is
+outside the portfolio's control and would introduce false failures. Where an
+external destination is important, verify the configured `href`; do not make
+the build depend on the third party returning a successful response.
+
+## Representative viewports
+
+Automated tests run in Chromium at:
+
+| Project | Viewport   | Purpose                                                    |
+| ------- | ---------- | ---------------------------------------------------------- |
+| Desktop | 1440 × 900 | Common laptop and desktop layout                           |
+| Tablet  | 768 × 1024 | Primary responsive breakpoint and narrow landscape content |
+| Mobile  | 390 × 844  | Common modern mobile viewport                              |
+
+These viewports provide consistent regression signals; they do not represent
+every device. Manual testing should also resize around breakpoints rather than
+checking only the exact configured widths. Defects often occur immediately
+before or after a breakpoint, not at the breakpoint itself.
+
+## Environments
+
+### Local development
+
+Use the development server for rapid investigation and exploratory testing:
+
+```bash
+npm run dev
+```
+
+Development-server behaviour is useful feedback, but it is not final release
+evidence.
+
+### Local production build
+
+The default Playwright run builds the application and starts the Vite preview
+server automatically:
+
+```bash
+npm run test:e2e
+```
+
+This is the primary automated environment because it is deterministic and
+represents the generated application that will be deployed.
+
+### Cloudflare preview
+
+Use the preview deployment to verify Cloudflare routing, asset delivery,
+headers, and environment-specific behaviour before merging:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://preview-url.pages.dev npm run test:e2e
+```
+
+The preview must correspond to the commit under review. Record the tested URL
+and commit when reporting release evidence.
+
+### Production
+
+Production smoke tests must be read-only and safe to repeat:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://kitakamunyao.com npm run test:e2e
+```
+
+Do not use production automation for destructive actions, mutable test data,
+or checks that could generate unwanted communication or analytics noise.
+
+## Running and debugging Playwright
+
+Install the project dependencies from the lockfile:
+
+```bash
+npm ci
+```
+
+Install the Chromium version managed by Playwright:
+
+```bash
+npx playwright install chromium
+```
+
+On a Linux CI runner that also needs browser system dependencies, use:
+
+```bash
+npx playwright install --with-deps chromium
+```
+
+Run the complete suite:
+
+```bash
+npm run test:e2e
+```
+
+Run with a visible browser:
+
+```bash
+npm run test:e2e:headed
+```
+
+Use Playwright's interactive runner:
+
+```bash
+npm run test:e2e:ui
+```
+
+Open the latest HTML report:
+
+```bash
+npm run test:e2e:report
+```
+
+Run one file:
+
+```bash
+npx playwright test tests/errors.spec.ts
+```
+
+Run one project:
+
+```bash
+npx playwright test --project=mobile
+```
+
+Run a test selected by title:
+
+```bash
+npx playwright test -g "skip link"
+```
+
+When a test fails, review the assertion message, screenshot, trace, video, page
+URL, and console output before changing the test. Confirm whether the expected
+behaviour is still valid. Do not update an assertion merely to match a new
+result without understanding why the result changed.
+
+## Test design standards
+
+New Playwright tests should:
+
+- use `getByRole`, labels, and accessible names where possible;
+- contain an assertion that expresses visitor value;
+- start from an explicit route or state;
+- avoid fixed waits and arbitrary timeouts;
+- rely on Playwright's web-first assertions;
+- avoid order dependence and shared mutable state;
+- avoid checking exact layout values unless they represent a requirement;
+- avoid screenshots as the only assertion;
+- be safe to run against preview and production when practical;
+- include a clear test name that describes the expected behaviour.
+
+CSS selectors are appropriate when the behaviour under test has no accessible
+surface, such as detecting horizontal overflow or verifying a reduced-motion
+layout rule. Their use should be deliberate rather than the default.
+
+## Manual regression checklist
+
+Use judgement when selecting the depth of regression. A content-only change
+does not require the same breadth as routing, navigation, or global CSS work.
+Record any omitted area and the reason it was considered low risk.
+
+### Content and presentation
+
+- [ ] Confirm headings, summaries, dates, role information, and links are
+      accurate.
+- [ ] Review spelling, punctuation, line breaks, and typographic characters.
+- [ ] Confirm long-form content remains readable and paragraphs are not overly
+      wide or dense.
+- [ ] Check long headings and paragraphs for awkward wrapping.
+- [ ] Confirm hover, active, and focus treatments remain visually consistent.
+- [ ] Confirm the footer is positioned appropriately on both short and long
+      pages.
+
+### Navigation and routing
+
+- [ ] Navigate through the site without manually editing the URL.
+- [ ] Open important internal links in a new tab where browser behaviour allows.
+- [ ] Load nested routes directly and refresh them.
+- [ ] Verify hash links stop at a useful position below sticky navigation.
+- [ ] Verify browser Back and Forward after both route and hash navigation.
+- [ ] Confirm invalid routes explain what happened and provide an appropriate
+      recovery path.
+- [ ] Check that external links point to the intended destinations without
+      submitting data or relying on those sites for build success.
+
+### Keyboard and accessibility
+
+- [ ] Complete each critical journey using only the keyboard.
+- [ ] Verify focus order follows the visual and semantic reading order.
+- [ ] Verify the skip link appears on focus and moves focus to the main content.
+- [ ] Confirm every interactive control has a visible focus indicator.
+- [ ] Confirm focus is not obscured by sticky content.
+- [ ] Check that link names make sense without surrounding prose.
+- [ ] Confirm each page has one descriptive `<h1>` and headings do not skip
+      levels without reason.
+- [ ] Review landmarks and page regions with browser accessibility tools or a
+      screen reader.
+- [ ] Check meaningful content at 200% browser zoom.
+- [ ] Check Windows High Contrast or forced-colours mode when global colour or
+      focus styles change.
+- [ ] Verify the experience with reduced motion enabled.
+
+Automated accessibility checks are useful but cannot establish that the page is
+understandable, logically ordered, or pleasant to use. Manual keyboard and
+assistive-technology review remains necessary.
+
+### Responsive behaviour
+
+- [ ] Review desktop, tablet, and mobile layouts.
+- [ ] Resize through responsive breakpoints and inspect widths immediately on
+      both sides of each breakpoint.
+- [ ] Verify no unintended horizontal scrolling occurs.
+- [ ] Confirm navigation remains readable and operable at narrow widths.
+- [ ] Confirm headings, metadata, code blocks, and long links wrap safely.
+- [ ] Check portrait and landscape where the change affects viewport-dependent
+      layout.
+- [ ] Check touch targets and spacing on a real mobile device when practical.
+
+### Colour and motion
+
+- [ ] Review both light and dark colour schemes.
+- [ ] Confirm text, borders, focus indicators, and accents remain distinguishable.
+- [ ] Check that colour is not the only way information is communicated.
+- [ ] Confirm animations do not obstruct interaction or delay access to content.
+- [ ] Confirm reduced-motion mode removes non-essential movement without hiding
+      content.
+
+### SEO and metadata
+
+- [ ] Confirm every indexable page has a useful, unique title and description.
+- [ ] Confirm canonical URLs reference the intended production URL.
+- [ ] Confirm article and case-study metadata matches visible content.
+- [ ] Confirm error pages use `noindex` and do not declare invalid canonicals.
+- [ ] Check Open Graph data and the social image after metadata changes.
+- [ ] Confirm `robots.txt` and `sitemap.xml` remain reachable and accurate.
+
+Do not use an error page's Lighthouse SEO score as a release target. Lighthouse
+correctly reports `noindex` as failing its indexability audit, while `noindex`
+is the intended behaviour for these pages.
+
+### Performance
+
+- [ ] Run Lighthouse against representative content, not only the homepage.
+- [ ] Include at least one long article or case study.
+- [ ] Run mobile audits multiple times and use the median result.
+- [ ] Review LCP, CLS, TBT/INP, and asset weight rather than relying only on the
+      aggregate score.
+- [ ] Investigate consistent regressions; do not chase normal one- or two-point
+      laboratory variance.
+- [ ] Confirm fonts and key content do not shift unexpectedly during loading.
+
+### Deployment smoke test
+
+- [ ] Confirm the deployed commit matches the commit that was approved.
+- [ ] Open the homepage and at least one nested route directly.
+- [ ] Refresh a nested route.
+- [ ] Exercise one primary navigation path and one recovery path.
+- [ ] Inspect the browser console for new errors or warnings.
+- [ ] Confirm expected response headers and status codes where hosting behaviour
+      matters.
+- [ ] Confirm preview deployments include indexing protection.
+
+## Exploratory testing
+
+Use short, focused charters rather than unstructured browsing. Examples:
+
+- Explore navigation while alternating mouse, keyboard, Back, Forward, refresh,
+  and direct URL entry.
+- Explore the site at extreme zoom and narrow widths using the longest available
+  article and case-study content.
+- Explore how the site communicates failure when route segments, slugs, hashes,
+  and trailing slashes are unexpected.
+- Explore reading continuity while switching colour scheme or reduced-motion
+  preference.
+- Explore whether sticky and fixed elements obscure content, focus, or browser
+  find results.
+
+Time-box a charter, record the environment and scope, and distinguish observed
+facts from questions or risks that require further investigation.
+
+## Failure investigation
+
+When a check fails, capture:
+
+- the tested commit and environment;
+- the exact route and viewport;
+- reproducible steps;
+- expected and observed behaviour;
+- screenshots, trace, video, console output, or response headers as relevant;
+- whether the failure reproduces locally, in preview, and in production;
+- user impact and release risk.
+
+Classify the failure before acting:
+
+- **Product defect:** the implemented behaviour violates the expectation.
+- **Test defect:** the assertion, selector, setup, or synchronisation is wrong.
+- **Environment defect:** infrastructure or configuration prevents a valid test.
+- **Expected change:** the requirement changed and both the implementation and
+  test need an intentional update.
+- **External dependency:** a third party is unavailable or has changed outside
+  the portfolio's control.
+
+## Release evidence and exit criteria
+
+A change is ready to merge when:
+
+- relevant acceptance criteria are satisfied;
+- TypeScript and the production build succeed;
+- ESLint succeeds;
+- relevant automated tests pass;
+- appropriate manual and exploratory checks are complete;
+- failures and intentionally omitted checks are understood and recorded;
+- the Cloudflare preview has been reviewed when deployment behaviour is in
+  scope;
+- no known issue presents an unacceptable visitor, accessibility, SEO, or
+  operational risk.
+
+Passing automation is necessary evidence, not automatic approval to release.
+The release decision should consider the nature of the change, unresolved risk,
+and the quality of the evidence available.
+
+## Known limitations and future considerations
+
+- Playwright currently runs Chromium only. Cross-browser visual review remains
+  manual until Firefox or WebKit coverage provides enough value to justify its
+  cost.
+- Cloudflare Pages currently serves the SPA shell with HTTP `200` for unknown
+  routes. React renders the correct error state, but true server-level `404`
+  responses are tracked separately.
+- The suite does not validate third-party availability.
+- Automated visual comparison is intentionally excluded. Introduce it only for
+  stable, high-value surfaces with a demonstrated regression history.
+- Automated accessibility tooling may be added later, but it will complement
+  rather than replace keyboard, screen-reader, zoom, contrast, and usability
+  review.
+
+Review this strategy whenever the site's architecture, content model,
+deployment platform, supported browsers, or principal user journeys change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^24.13.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -584,6 +585,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2374,6 +2391,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.3.0",
@@ -18,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^24.13.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:4173";
+
+export default defineConfig({
+  testDir: "./tests",
+
+  fullyParallel: true,
+
+  forbidOnly: Boolean(process.env.CI),
+
+  retries: process.env.CI ? 2 : 0,
+
+  workers: process.env.CI ? 1 : undefined,
+
+  reporter: [["html", { open: "never" }], ["list"]],
+
+  use: {
+    baseURL,
+
+    trace: "on-first-retry",
+
+    screenshot: "only-on-failure",
+
+    video: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "desktop",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: {
+          width: 1440,
+          height: 900,
+        },
+      },
+    },
+    {
+      name: "tablet",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: {
+          width: 768,
+          height: 1024,
+        },
+      },
+    },
+    {
+      name: "mobile",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: {
+          width: 390,
+          height: 844,
+        },
+      },
+    },
+  ],
+
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: "npm run build && npm run preview -- --host 127.0.0.1",
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+      },
+});

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("accessibility", () => {
+  test("skip link is first in the keyboard order and moves focus to main", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const skipLink = page.getByRole("link", { name: "Skip to main content" });
+
+    await page.keyboard.press("Tab");
+    await expect(skipLink).toBeFocused();
+    await expect(skipLink).toBeVisible();
+
+    await page.keyboard.press("Enter");
+
+    await expect(page).toHaveURL(/#main-content$/);
+    await expect(page.getByRole("main")).toBeFocused();
+  });
+
+  test("recovery link has a visible keyboard focus indicator", async ({
+    page,
+  }) => {
+    await page.goto("/this-page-does-not-exist");
+
+    const recoveryLink = page.getByRole("link", {
+      name: "Return to the homepage",
+    });
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+
+    await expect(recoveryLink).toBeFocused();
+    await expect(recoveryLink).toHaveCSS("outline-style", "solid");
+    await expect(recoveryLink).toHaveCSS("outline-width", "3px");
+    await expect(recoveryLink).toHaveCSS("outline-offset", "4px");
+  });
+
+  test("reduced motion removes the fixed hero transition layout", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+
+    await expect(page.locator(".home-hero-layer")).toHaveCSS(
+      "position",
+      "relative",
+    );
+    await expect(page.locator(".home-hero-layer")).toHaveCSS("opacity", "1");
+    await expect(page.locator(".home-hero-space")).toHaveCSS("display", "none");
+  });
+});

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+
+const errorStates = [
+  {
+    name: "unknown page",
+    path: "/this-page-does-not-exist",
+    title: "Page not found | Kitaka",
+    heading: "This page doesn’t exist.",
+    recoveryLabel: "Return to the homepage",
+    recoveryPath: "/",
+  },
+  {
+    name: "unknown article",
+    path: "/writing/this-article-does-not-exist",
+    title: "Article not found | Kitaka",
+    heading: "Article not found.",
+    recoveryLabel: "Browse all writing",
+    recoveryPath: "/writing",
+  },
+  {
+    name: "unknown case study",
+    path: "/case-studies/this-case-study-does-not-exist",
+    title: "Case study not found | Kitaka",
+    heading: "Case study not found.",
+    recoveryLabel: "Return to experience",
+    recoveryPath: "/#experience",
+  },
+];
+
+test.describe("error states", () => {
+  for (const errorState of errorStates) {
+    test(`${errorState.name} provides a complete recovery experience`, async ({
+      page,
+    }) => {
+      await page.goto(errorState.path);
+
+      await expect(page).toHaveTitle(errorState.title);
+      await expect(
+        page.getByRole("heading", {
+          level: 1,
+          name: errorState.heading,
+        }),
+      ).toBeVisible();
+      await expect(page.locator("h1")).toHaveCount(1);
+
+      await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+        "content",
+        "noindex, follow",
+      );
+      await expect(page.locator('link[rel="canonical"]')).toHaveCount(0);
+
+      await expect(page.getByRole("main")).toBeVisible();
+      await expect(page.getByRole("contentinfo")).toBeVisible();
+      await expect(page.getByRole("navigation")).toHaveCount(0);
+
+      const recoveryLink = page.getByRole("link", {
+        name: errorState.recoveryLabel,
+      });
+
+      await expect(recoveryLink).toHaveAttribute("href", errorState.recoveryPath);
+      await recoveryLink.click();
+      await expect(page).toHaveURL(errorState.recoveryPath);
+    });
+  }
+});

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+const primaryNavigation = [
+  { name: "About", hash: "#about" },
+  { name: "Experience", hash: "#experience" },
+  { name: "Skills", hash: "#skills" },
+  { name: "Contact", hash: "#contact" },
+];
+
+const caseStudies = [
+  {
+    company: "Harvest",
+    path: "/case-studies/harvest",
+    heading: "Building confidence across a connected product ecosystem",
+  },
+  {
+    company: "Chili Piper",
+    path: "/case-studies/chili-piper",
+    heading: "Quality begins with understanding the system",
+  },
+  {
+    company: "Sitemate",
+    path: "/case-studies/sitemate",
+    heading: "Building quality from the ground up",
+  },
+];
+
+test.describe("navigation", () => {
+  test("primary navigation reaches each homepage section", async ({ page }) => {
+    await page.goto("/");
+
+    for (const item of primaryNavigation) {
+      await page.getByRole("link", { name: item.name, exact: true }).click();
+
+      await expect(page).toHaveURL(item.hash);
+      await expect(page.locator(item.hash)).toBeInViewport();
+    }
+  });
+
+  test("homepage links reach How I work and Writing", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("link", { name: "How I work", exact: true }).click();
+    await expect(page).toHaveURL("/how-i-work");
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Understanding products. Building confidence.",
+      }),
+    ).toBeVisible();
+
+    await page.goto("/");
+    await page.getByRole("link", { name: "Writing", exact: true }).click();
+    await expect(page).toHaveURL("/writing");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Writing" }),
+    ).toBeVisible();
+  });
+
+  for (const caseStudy of caseStudies) {
+    test(`${caseStudy.company} link opens the correct case study`, async ({
+      page,
+    }) => {
+      await page.goto("/#experience");
+
+      const experience = page
+        .locator(".experience-item")
+        .filter({ hasText: caseStudy.company });
+
+      await experience
+        .getByRole("link", { name: "Read the case study" })
+        .click();
+
+      await expect(page).toHaveURL(caseStudy.path);
+      await expect(
+        page.getByRole("heading", {
+          level: 1,
+          name: caseStudy.heading,
+        }),
+      ).toBeVisible();
+    });
+  }
+
+  test("directional links return to their parent pages", async ({ page }) => {
+    await page.goto("/how-i-work");
+    await page.getByRole("link", { name: "Back to home" }).click();
+    await expect(page).toHaveURL("/");
+
+    await page.goto("/writing/testing-is-information-not-approval");
+    await page.getByRole("link", { name: "Back to writing" }).first().click();
+    await expect(page).toHaveURL("/writing");
+
+    await page.goto("/case-studies/harvest");
+    await page.getByRole("link", { name: "Back to experience" }).click();
+    await expect(page).toHaveURL("/#experience");
+    await expect(page.locator("#experience")).toBeInViewport();
+  });
+
+  test("browser Back and Forward preserve navigation history", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: "Writing", exact: true }).click();
+    await expect(page).toHaveURL("/writing");
+
+    await page.goBack();
+    await expect(page).toHaveURL("/");
+
+    await page.goForward();
+    await expect(page).toHaveURL("/writing");
+  });
+});

--- a/tests/routes.spec.ts
+++ b/tests/routes.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+const routes = [
+  {
+    name: "homepage",
+    path: "/",
+    heading: "Quality starts long before testing.",
+  },
+  {
+    name: "How I work",
+    path: "/how-i-work",
+    heading: "Understanding products. Building confidence.",
+  },
+  {
+    name: "Writing index",
+    path: "/writing",
+    heading: "Writing",
+  },
+  {
+    name: "article",
+    path: "/writing/testing-is-information-not-approval",
+    heading: "Testing is information, not approval",
+  },
+  {
+    name: "Harvest case study",
+    path: "/case-studies/harvest",
+    heading: "Building confidence across a connected product ecosystem",
+  },
+  {
+    name: "Chili Piper case study",
+    path: "/case-studies/chili-piper",
+    heading: "Quality begins with understanding the system",
+  },
+  {
+    name: "Sitemate case study",
+    path: "/case-studies/sitemate",
+    heading: "Building quality from the ground up",
+  },
+];
+
+test.describe("core routes", () => {
+  for (const route of routes) {
+    test(`${route.name} loads directly`, async ({ page }) => {
+      const response = await page.goto(route.path);
+
+      expect(response?.status()).toBe(200);
+
+      await expect(
+        page.getByRole("heading", {
+          level: 1,
+          name: route.heading,
+        }),
+      ).toBeVisible();
+
+      await expect(page.locator("h1")).toHaveCount(1);
+
+      const horizontalOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth - window.innerWidth,
+      );
+
+      expect(horizontalOverflow).toBeLessThanOrEqual(0);
+    });
+  }
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "es2023",
-    "lib": ["ES2023"],
-    "types": ["node"],
+    "lib": ["ES2023", "DOM"],
+    "types": ["node", "@playwright/test"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -19,5 +19,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts", "tests"]
 }


### PR DESCRIPTION
## Summary

Introduces a focused Playwright test suite for the portfolio’s critical routes, navigation, accessibility, responsive behaviour, and error states.

The suite prioritises meaningful user journeys while avoiding brittle assertions against low-value visual details.

Closes #57 

## Changes

- Added Playwright and Chromium-based end-to-end testing.
- Added desktop, tablet, and mobile test projects.
- Added configurable local, preview, and production base URLs.
- Added route coverage for all current pages.
- Added primary, directional, hash, and browser-history navigation tests.
- Added coverage for all case-study links.
- Added unknown route, article, and case-study tests.
- Added skip-link and keyboard-focus coverage.
- Added reduced-motion behaviour coverage.
- Added horizontal-overflow checks.
- Added Playwright reports and test results to `.gitignore`.
- Added GitHub Actions coverage for pull requests and `main`.
- Updated the TypeScript tooling configuration for Playwright and Node types.

## Automated coverage

### Core routes

- [x] Homepage
- [x] How I work
- [x] Writing index
- [x] Article route
- [x] Harvest case study
- [x] Chili Piper case study
- [x] Sitemate case study
- [x] Direct route loading
- [x] Primary heading structure
- [x] Horizontal overflow

### Navigation

- [x] Primary homepage navigation
- [x] Hash navigation
- [x] How I work and Writing links
- [x] Case-study links
- [x] Directional and back links
- [x] Browser Back and Forward behaviour

### Accessibility

- [x] Skip-link keyboard order
- [x] Focus movement to the main content
- [x] Visible keyboard focus
- [x] Semantic main and footer landmarks
- [x] Single primary heading
- [x] Reduced-motion behaviour

### Error states

- [x] Unknown top-level route
- [x] Unknown article slug
- [x] Unknown case-study slug
- [x] Contextual headings and recovery links
- [x] `noindex, follow` metadata
- [x] Absence of canonical metadata
- [x] Complete page structure

### Responsive coverage

The automated suite runs against:

- Desktop: `1440 × 900`
- Tablet: `768 × 1024`
- Mobile: `390 × 844`

## Commands

Run the complete suite:

```bash
npm run test:e2e