### PR TITLE
Feature/story 4 7 mobile navigation hero refinement

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Install Chromium
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Run ESLint
         run: npm run lint

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -159,7 +159,7 @@
   }
 
   .home-hero-space {
-    height: calc(100svh - var(--header-offset));
+    height: calc(88svh - var(--header-offset));
   }
 
   .home-content::before {

--- a/src/shared/Footer.css
+++ b/src/shared/Footer.css
@@ -1,12 +1,26 @@
 .footer {
-  max-width: var(--max-width);
-  margin: 0 auto;
+  position: relative;
+
+  z-index: 1;
+
+  width: 100%;
+
+  box-sizing: border-box;
+
   padding: var(--space-lg) var(--space-md);
+
+  background: var(--color-background);
 
   text-align: center;
 
   color: var(--color-text);
   font-size: 0.95rem;
+}
+
+.footer p {
+  max-width: var(--max-width);
+
+  margin: 0 auto;
 }
 
 @media (max-width: 768px) {

--- a/src/shared/Navbar.css
+++ b/src/shared/Navbar.css
@@ -90,6 +90,10 @@
   color: var(--color-accent);
 }
 
+.navbar-menu-button {
+  display: none;
+}
+
 @media (max-width: 768px) {
   .navbar-inner {
     padding: var(--space-sm);
@@ -105,5 +109,132 @@
 
   .navbar-links a {
     font-size: 0.85rem;
+  }
+}
+
+@media (max-width: 350px) {
+  .navbar {
+    position: relative;
+  }
+
+  .navbar-menu-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    min-height: 44px;
+
+    gap: 0.4rem;
+
+    margin: -0.5rem 0;
+    padding: 0.5rem 0;
+
+    border: 0;
+
+    background: transparent;
+
+    color: var(--color-text);
+
+    font: inherit;
+    font-size: 0.9rem;
+
+    cursor: pointer;
+  }
+
+  .navbar-menu-button:hover {
+    color: var(--color-heading);
+  }
+
+  .navbar-menu-button:focus-visible {
+    outline: 3px solid var(--color-accent);
+    outline-offset: 3px;
+
+    border-radius: 4px;
+  }
+
+  .navbar-menu-icon {
+    color: var(--color-accent);
+
+    transition: transform var(--transition);
+  }
+
+  .navbar-menu-button[aria-expanded="true"] .navbar-menu-icon {
+    transform: rotate(180deg);
+  }
+
+  .navbar-links {
+    position: absolute;
+    top: 100%;
+    right: var(--space-sm);
+
+    display: block;
+    align-items: stretch;
+
+    width: min(12rem, calc(100vw - (2 * var(--space-sm))));
+
+    gap: 0;
+
+    padding: 0.35rem;
+
+    border: 1px solid var(--color-border);
+
+    background: color-mix(
+      in srgb,
+      var(--color-background) 96%,
+      transparent
+    );
+
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(-4px);
+    pointer-events: none;
+
+    transition:
+      visibility 0s linear 200ms,
+      opacity var(--transition),
+      transform var(--transition);
+  }
+
+  .navbar-links.is-open {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+
+    transition-delay: 0s;
+  }
+
+  .navbar-links a {
+    display: flex;
+    align-items: center;
+
+    min-height: 44px;
+
+    box-sizing: border-box;
+
+    padding: 0.65rem 0.75rem;
+
+    border-bottom-width: 1px;
+
+    transition:
+      color var(--transition),
+      border-color var(--transition),
+      transform var(--transition);
+  }
+
+  .navbar-links a:hover,
+  .navbar-links a:focus-visible {
+    transform: translateX(3px);
+  }
+}
+
+@media (max-width: 350px) and (prefers-reduced-motion: reduce) {
+  .navbar-menu-icon,
+  .navbar-links,
+  .navbar-links a {
+    transition: none;
   }
 }

--- a/src/shared/Navbar.tsx
+++ b/src/shared/Navbar.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+
 import { useActiveSection } from "../hooks/useActiveSection";
 
 import "./Navbar.css";
@@ -6,23 +8,89 @@ const SECTION_IDS = ["experience", "how-i-work", "writing", "contact"];
 
 function Navbar() {
   const activeSection = useActiveSection(SECTION_IDS);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const navigationRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+
+      setIsMenuOpen(false);
+      menuButtonRef.current?.focus();
+    };
+
+    const closeOnOutsideClick = (event: PointerEvent) => {
+      if (navigationRef.current?.contains(event.target as Node)) return;
+
+      setIsMenuOpen(false);
+    };
+
+    document.addEventListener("keydown", closeOnEscape);
+    document.addEventListener("pointerdown", closeOnOutsideClick);
+
+    return () => {
+      document.removeEventListener("keydown", closeOnEscape);
+      document.removeEventListener("pointerdown", closeOnOutsideClick);
+    };
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    const wideNavigation = window.matchMedia("(min-width: 351px)");
+    const closeCompactMenu = (event: MediaQueryListEvent) => {
+      if (event.matches) setIsMenuOpen(false);
+    };
+
+    wideNavigation.addEventListener("change", closeCompactMenu);
+
+    return () => {
+      wideNavigation.removeEventListener("change", closeCompactMenu);
+    };
+  }, []);
+
+  const closeMenu = () => setIsMenuOpen(false);
 
   return (
     <header className="site-header">
-      <nav className="navbar" aria-label="Primary navigation">
+      <nav
+        ref={navigationRef}
+        className="navbar"
+        aria-label="Primary navigation"
+      >
         <div className="navbar-inner">
           <a
             className="navbar-logo"
             href="#top"
             aria-label="Kitaka Munyao home"
+            onClick={closeMenu}
           >
             Kitaka
           </a>
 
-          <ul className="navbar-links">
+          <button
+            ref={menuButtonRef}
+            className="navbar-menu-button"
+            type="button"
+            aria-expanded={isMenuOpen}
+            aria-controls="primary-navigation-links"
+            onClick={() => setIsMenuOpen((isOpen) => !isOpen)}
+          >
+            <span>Menu</span>
+            <span className="navbar-menu-icon" aria-hidden="true">
+              ↓
+            </span>
+          </button>
+
+          <ul
+            id="primary-navigation-links"
+            className={`navbar-links${isMenuOpen ? " is-open" : ""}`}
+          >
             <li>
               <a
                 href="#experience"
+                onClick={closeMenu}
                 className={activeSection === "experience" ? "active" : ""}
                 aria-current={
                   activeSection === "experience" ? "location" : undefined
@@ -35,6 +103,7 @@ function Navbar() {
             <li>
               <a
                 href="#how-i-work"
+                onClick={closeMenu}
                 className={activeSection === "how-i-work" ? "active" : ""}
                 aria-current={
                   activeSection === "how-i-work" ? "location" : undefined
@@ -47,6 +116,7 @@ function Navbar() {
             <li>
               <a
                 href="#writing"
+                onClick={closeMenu}
                 className={activeSection === "writing" ? "active" : ""}
                 aria-current={
                   activeSection === "writing" ? "location" : undefined
@@ -59,6 +129,7 @@ function Navbar() {
             <li>
               <a
                 href="#contact"
+                onClick={closeMenu}
                 className={activeSection === "contact" ? "active" : ""}
                 aria-current={
                   activeSection === "contact" ? "location" : undefined

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -54,7 +54,7 @@ test.describe("accessibility", () => {
   });
 
   test("hero remains readable at a narrow mobile width", async ({ page }) => {
-    await page.setViewportSize({ width: 320, height: 720 });
+    await page.setViewportSize({ width: 320, height: 568 });
     await page.goto("/");
 
     await expect(
@@ -64,12 +64,87 @@ test.describe("accessibility", () => {
       }),
     ).toBeVisible();
     await expect(page.locator(".hero-intro")).toBeVisible();
+    await expect(page.locator(".home-hero-layer")).toHaveCSS(
+      "position",
+      "fixed",
+    );
+
+    const experienceTop = await page
+      .locator("#experience")
+      .evaluate((element) => element.getBoundingClientRect().top);
+
+    expect(experienceTop).toBeLessThan(568);
 
     const horizontalOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth - window.innerWidth,
     );
 
     expect(horizontalOverflow).toBeLessThanOrEqual(0);
+  });
+
+  test("compact navigation supports touch and keyboard operation", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto("/");
+
+    const menuButton = page.getByRole("button", { name: "Menu" });
+
+    await menuButton.focus();
+    await expect(menuButton).toHaveCSS("outline-style", "solid");
+    await expect(menuButton).toHaveCSS("outline-width", "3px");
+
+    await menuButton.press("Enter");
+
+    const navigationLinks = page.locator(".navbar-links").getByRole("link");
+
+    for (const link of await navigationLinks.all()) {
+      const height = await link.evaluate(
+        (element) => element.getBoundingClientRect().height,
+      );
+
+      expect(Math.round(height)).toBeGreaterThanOrEqual(44);
+    }
+
+    const experienceLink = page.getByRole("link", {
+      name: "Experience",
+      exact: true,
+    });
+
+    await experienceLink.focus();
+    await experienceLink.press("Escape");
+
+    await expect(menuButton).toHaveAttribute("aria-expanded", "false");
+    await expect(menuButton).toBeFocused();
+  });
+
+  test("footer covers the fixed hero at the bottom of a short landscape viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 882, height: 344 });
+    await page.goto("/");
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    const footerLayout = await page.locator(".footer").evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      const styles = getComputedStyle(element);
+
+      return {
+        backgroundColor: styles.backgroundColor,
+        bottom: rect.bottom,
+        viewportHeight: window.innerHeight,
+        width: rect.width,
+        viewportWidth: window.innerWidth,
+      };
+    });
+
+    expect(footerLayout.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(
+      Math.abs(footerLayout.bottom - footerLayout.viewportHeight),
+    ).toBeLessThanOrEqual(1);
+    expect(footerLayout.width).toBeGreaterThanOrEqual(
+      footerLayout.viewportWidth - 2,
+    );
   });
 
   test("experience case-study links retain a visible focus indicator", async ({

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -56,6 +56,61 @@ test.describe("navigation", () => {
       .toBe(0);
   });
 
+  test("compact navigation reaches a section without obscuring it", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto("/");
+
+    const menuButton = page.getByRole("button", { name: "Menu" });
+
+    await expect(menuButton).toBeVisible();
+    await expect(menuButton).toHaveAttribute("aria-expanded", "false");
+
+    await menuButton.click();
+
+    await expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    const howIWorkLink = page.getByRole("link", {
+      name: "How I work",
+      exact: true,
+    });
+
+    await expect(howIWorkLink).toBeVisible();
+    await howIWorkLink.click();
+
+    await expect(page).toHaveURL("/#how-i-work");
+    await expect(menuButton).toHaveAttribute("aria-expanded", "false");
+
+    const targetPosition = await page.evaluate(() => ({
+      headerBottom: document
+        .querySelector(".site-header")!
+        .getBoundingClientRect().bottom,
+      sectionTop: document
+        .querySelector("#how-i-work")!
+        .getBoundingClientRect().top,
+    }));
+
+    expect(targetPosition.sectionTop).toBeGreaterThanOrEqual(
+      targetPosition.headerBottom,
+    );
+  });
+
+  test("full navigation remains visible above the compact breakpoint", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 360, height: 800 });
+    await page.goto("/");
+
+    await expect(page.getByRole("button", { name: "Menu" })).toBeHidden();
+
+    for (const item of primaryNavigation) {
+      await expect(
+        page.getByRole("link", { name: item.name, exact: true }),
+      ).toBeVisible();
+    }
+  });
+
   test("homepage content links reach How I work and Writing", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Closes #69.

Refines the mobile hero and primary navigation so the homepage remains usable below 390px, during narrow reflow and on short landscape viewports.

The existing visible navigation remains unchanged where it fits. At 350px and below, it is replaced with an accessible compact menu that preserves every primary destination without changing the sticky-header height.

The fixed hero has been retained, with a shorter mobile spacer allowing the beginning of Experience to provide a natural continuation cue.

## Changes

### Mobile navigation

- Added a compact navigation menu at 350px and below.
- Preserved the existing visible navigation above the compact breakpoint.
- Kept the Kitaka home link visible.
- Added a stable “Menu” label with a rotating directional arrow.
- Added `aria-expanded` and `aria-controls`.
- Added 44px navigation targets.
- Added Escape-key dismissal and focus return.
- Added outside-click dismissal.
- Close the menu after selecting a navigation link.
- Clear the open state when changing to a wider viewport.
- Preserved active-section feedback.
- Added a restrained panel reveal and link movement.
- Disabled menu animation under reduced motion.

### Mobile hero

- Preserved the fixed and fading hero treatment.
- Shortened the mobile hero spacer to reveal the beginning of Experience.
- Used subsequent content as the continuation cue rather than adding a decorative scroll indicator.
- Preserved the existing `#top` behaviour.
- Kept section headings clear of the sticky header.

### Landscape footer regression

- Fixed the faded hero appearing beneath the footer on short landscape viewports.
- Made the shared footer an opaque full-width page layer.
- Preserved its constrained and centred content.
- Verified the fix at 882×344.
- Added automated regression coverage.

### Testing

Added coverage for:

- Compact-menu visibility and state
- Keyboard operation and focus return
- Minimum touch-target height
- Selecting a compact-menu destination
- Hash targets clearing the sticky header
- Full navigation remaining visible above the compact breakpoint
- Fixed mobile hero behaviour
- Experience appearing within the mobile viewport
- Horizontal overflow
- Short-landscape footer coverage

### Continuous integration

- Investigated the cancelled GitHub Actions runs.
- Confirmed CI timed out during Playwright’s Ubuntu system-package installation.
- Removed `--with-deps` from the Chromium installation step.
- CI now installs the matching Chromium binary without invoking the unreliable Ubuntu package mirror.

## Decisions and trade-offs

- A two-row mobile header was explored and rejected because it left visually unbalanced space beside the logo.
- The compact menu is introduced only when the existing navigation genuinely stops fitting.
- The visible “Menu” label remains stable in both states; the arrow and `aria-expanded` communicate state.
- A hamburger-only control was avoided because the textual label is clearer and better suited to the portfolio’s editorial character.
- The fixed hero was retained rather than replaced with a normal-flow mobile layout.
- Menu animation remains subtle and is removed when reduced motion is preferred.
- Comparative Lighthouse testing remains deferred to the milestone-level performance review.

## Verification

- [x] ESLint passed.
- [x] Production build passed.
- [x] Full Playwright suite passed: 90 tests.
- [x] Reviewed desktop, tablet and mobile layouts.
- [x] Reviewed 320px, 360px and 390px widths.
- [x] Reviewed a short 882×344 landscape viewport.
- [x] Verified keyboard dismissal and focus return.
- [x] Verified no horizontal overflow.
- [x] Verified reduced-motion support.
- [x] Confirm the corrected GitHub Actions workflow passes.
- [x] Complete manual 200% zoom and increased-text checks.
- [ ] Review light and dark modes.
- [ ] Review the Cloudflare preview.
- [ ] Review the preview on a real mobile device when practical.