### PR TITLE
fix: restore homepage hero initial state

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -77,6 +77,8 @@
 
   max-width: var(--max-width);
 
+  box-sizing: border-box;
+
   margin: 0 auto;
   padding: 0 var(--space-md) var(--home-section-space);
 }

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -6,7 +6,7 @@
   --hero-fade: 0;
 
   position: fixed;
-  top: var(--header-offset);
+  top: 0;
   left: 0;
 
   z-index: 0;
@@ -46,7 +46,7 @@
 }
 
 .home-hero-space {
-  height: calc(100svh - var(--header-offset));
+  height: 100svh;
 }
 
 .home-content {
@@ -159,7 +159,7 @@
   }
 
   .home-hero-space {
-    height: calc(88svh - var(--header-offset));
+    height: 100svh;
   }
 
   .home-content::before {

--- a/src/sections/Hero.css
+++ b/src/sections/Hero.css
@@ -11,7 +11,7 @@
   justify-content: center;
 
   max-width: var(--max-width);
-  min-height: calc(100svh - var(--header-offset));
+  min-height: 100svh;
 
   box-sizing: border-box;
 
@@ -115,5 +115,31 @@
   .hero-intro {
     font-size: 20px;
     line-height: 1.4;
+  }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+  .hero {
+    padding: 2.5rem var(--space-md) 2rem;
+  }
+
+  .hero .section-eyebrow {
+    margin-bottom: 0.75rem;
+
+    font-size: 0.8rem;
+  }
+
+  .hero h1 {
+    margin-bottom: var(--space-sm);
+
+    font-size: 30px;
+  }
+
+  .hero-intro {
+    max-width: 40rem;
+
+    margin-bottom: 0;
+
+    font-size: 18px;
   }
 }

--- a/src/shared/Navbar.css
+++ b/src/shared/Navbar.css
@@ -42,6 +42,8 @@
 
   max-width: var(--max-width);
 
+  box-sizing: border-box;
+
   margin: 0 auto;
   padding: var(--space-sm) var(--space-md);
 }

--- a/src/shared/Navbar.css
+++ b/src/shared/Navbar.css
@@ -1,11 +1,30 @@
 .site-header {
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
 
   z-index: var(--z-header);
 
+  width: 100%;
+
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
+
+  opacity: 0;
+  transform: translateY(-100%);
+  pointer-events: none;
+
+  transition:
+    opacity var(--transition),
+    transform var(--transition);
+}
+
+.site-header.is-visible,
+.site-header:focus-within {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+
 }
 
 .navbar {
@@ -235,6 +254,12 @@
   .navbar-menu-icon,
   .navbar-links,
   .navbar-links a {
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-header {
     transition: none;
   }
 }

--- a/src/shared/Navbar.tsx
+++ b/src/shared/Navbar.tsx
@@ -8,9 +8,55 @@ const SECTION_IDS = ["experience", "how-i-work", "writing", "contact"];
 
 function Navbar() {
   const activeSection = useActiveSection(SECTION_IDS);
+  const [isHeaderVisible, setIsHeaderVisible] = useState(
+    () =>
+      window.scrollY > 24 ||
+      (window.location.hash.length > 0 && window.location.hash !== "#top"),
+  );
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const navigationRef = useRef<HTMLElement>(null);
+  const showForInitialHashRef = useRef(
+    window.location.hash.length > 0 && window.location.hash !== "#top",
+  );
+
+  useEffect(() => {
+    let frameId = 0;
+
+    const updateHeaderVisibility = () => {
+      if (window.scrollY > 24) {
+        showForInitialHashRef.current = false;
+        setIsHeaderVisible(true);
+        return;
+      }
+
+      setIsHeaderVisible(showForInitialHashRef.current);
+    };
+
+    const handleHashChange = () => {
+      showForInitialHashRef.current =
+        window.scrollY <= 24 &&
+        window.location.hash.length > 0 &&
+        window.location.hash !== "#top";
+
+      updateHeaderVisibility();
+    };
+
+    const handleScroll = () => {
+      cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(updateHeaderVisibility);
+    };
+
+    updateHeaderVisibility();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("hashchange", handleHashChange);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("hashchange", handleHashChange);
+    };
+  }, []);
 
   useEffect(() => {
     if (!isMenuOpen) return;
@@ -53,7 +99,9 @@ function Navbar() {
   const closeMenu = () => setIsMenuOpen(false);
 
   return (
-    <header className="site-header">
+    <header
+      className={`site-header${isHeaderVisible ? " is-visible" : ""}`}
+    >
       <nav
         ref={navigationRef}
         className="navbar"

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -73,13 +73,88 @@ test.describe("accessibility", () => {
       .locator("#experience")
       .evaluate((element) => element.getBoundingClientRect().top);
 
-    expect(experienceTop).toBeLessThan(568);
+    expect(experienceTop).toBeGreaterThanOrEqual(568);
 
     const horizontalOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth - window.innerWidth,
     );
 
     expect(horizontalOverflow).toBeLessThanOrEqual(0);
+  });
+
+  test("homepage navigation yields to the hero until visitors interact", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+
+    const header = page.locator(".site-header");
+    const heroLayer = page.locator(".home-hero-layer");
+
+    await expect(header).toHaveCSS("opacity", "0");
+    await expect(heroLayer).toHaveCSS("opacity", "1");
+
+    const initialLayout = await page.evaluate(() => ({
+      experienceTop: document
+        .querySelector("#experience")!
+        .getBoundingClientRect().top,
+      viewportHeight: window.innerHeight,
+    }));
+
+    expect(initialLayout.experienceTop).toBeGreaterThanOrEqual(
+      initialLayout.viewportHeight,
+    );
+
+    await page.evaluate(() => window.scrollTo(0, 48));
+
+    await expect(header).toHaveCSS("opacity", "1");
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+
+    await expect(header).toHaveCSS("opacity", "0");
+  });
+
+  test("keyboard focus reveals the initially hidden navigation", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const header = page.locator(".site-header");
+    const homeLink = page.getByRole("link", { name: "Kitaka Munyao home" });
+
+    await page.keyboard.press("Tab");
+    await expect(
+      page.getByRole("link", { name: "Skip to main content" }),
+    ).toBeFocused();
+
+    await page.keyboard.press("Tab");
+
+    await expect(homeLink).toBeFocused();
+    await expect(header).toHaveCSS("opacity", "1");
+  });
+
+  test("short landscape loads with an unfaded, fully framed hero", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 882, height: 344 });
+    await page.goto("/");
+
+    await expect(page.locator(".site-header")).toHaveCSS("opacity", "0");
+    await expect(page.locator(".home-hero-layer")).toHaveCSS("opacity", "1");
+
+    const landscapeLayout = await page.evaluate(() => ({
+      experienceTop: document
+        .querySelector("#experience")!
+        .getBoundingClientRect().top,
+      heroHeight: document.querySelector(".hero")!.getBoundingClientRect()
+        .height,
+      viewportHeight: window.innerHeight,
+    }));
+
+    expect(landscapeLayout.heroHeight).toBe(landscapeLayout.viewportHeight);
+    expect(landscapeLayout.experienceTop).toBeGreaterThanOrEqual(
+      landscapeLayout.viewportHeight,
+    );
   });
 
   test("compact navigation supports touch and keyboard operation", async ({

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -34,6 +34,7 @@ const caseStudies = [
 test.describe("navigation", () => {
   test("primary navigation reaches each homepage section", async ({ page }) => {
     await page.goto("/");
+    await page.evaluate(() => window.scrollTo(0, 48));
 
     for (const item of primaryNavigation) {
       await page.getByRole("link", { name: item.name, exact: true }).click();
@@ -54,6 +55,23 @@ test.describe("navigation", () => {
     await expect
       .poll(() => page.evaluate(() => Math.round(window.scrollY)))
       .toBe(0);
+    await expect(page.locator(".site-header")).toHaveCSS("opacity", "0");
+  });
+
+  test("navigation hides at the top even when a section hash remains", async ({
+    page,
+  }) => {
+    await page.goto("/#contact");
+    await expect(page.locator("#contact")).toBeInViewport();
+    await expect(page.locator(".site-header")).toHaveCSS("opacity", "1");
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+
+    await expect(page).toHaveURL("/#contact");
+    await expect
+      .poll(() => page.evaluate(() => Math.round(window.scrollY)))
+      .toBe(0);
+    await expect(page.locator(".site-header")).toHaveCSS("opacity", "0");
   });
 
   test("compact navigation reaches a section without obscuring it", async ({
@@ -61,6 +79,7 @@ test.describe("navigation", () => {
   }) => {
     await page.setViewportSize({ width: 320, height: 568 });
     await page.goto("/");
+    await page.evaluate(() => window.scrollTo(0, 48));
 
     const menuButton = page.getByRole("button", { name: "Menu" });
 
@@ -101,6 +120,7 @@ test.describe("navigation", () => {
   }) => {
     await page.setViewportSize({ width: 360, height: 800 });
     await page.goto("/");
+    await page.evaluate(() => window.scrollTo(0, 48));
 
     await expect(page.getByRole("button", { name: "Menu" })).toBeHidden();
 


### PR DESCRIPTION
## Summary

Closes #80.

Restores the homepage hero’s full initial presentation across portrait and landscape viewports, then reveals navigation after scrolling or keyboard interaction.

Also fixes navigation remaining visible after returning to the top with a section hash retained.

## Verification

- ESLint passed
- Production build passed
- Playwright: 102/102 passed