### PR TITLE
fix: follow dynamic mobile viewport height

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -47,6 +47,7 @@
 
 .home-hero-space {
   height: 100svh;
+  height: 100dvh;
 }
 
 .home-content {
@@ -162,6 +163,7 @@
 
   .home-hero-space {
     height: 100svh;
+    height: 100dvh;
   }
 
   .home-content::before {

--- a/src/sections/Hero.css
+++ b/src/sections/Hero.css
@@ -12,6 +12,7 @@
 
   max-width: var(--max-width);
   min-height: 100svh;
+  min-height: 100dvh;
 
   box-sizing: border-box;
 


### PR DESCRIPTION
## Summary

Follow-up to #80.

Uses dynamic viewport height for the homepage hero and spacer so Safari follows the currently visible viewport when its browser controls expand or collapse.

## Verification

- ESLint passed
- Production build passed
- Responsive Playwright checks: 12/12 passed