### PR TITLE
fix: size hero from the visual viewport

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,4 +1,6 @@
 .home-flow {
+  --home-viewport-height: 100dvh;
+
   position: relative;
 }
 
@@ -46,8 +48,7 @@
 }
 
 .home-hero-space {
-  height: 100svh;
-  height: 100dvh;
+  height: var(--home-viewport-height, 100svh);
 }
 
 .home-content {
@@ -162,8 +163,7 @@
   }
 
   .home-hero-space {
-    height: 100svh;
-    height: 100dvh;
+    height: var(--home-viewport-height, 100svh);
   }
 
   .home-content::before {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 import Navbar from "../shared/Navbar";
 import Footer from "../shared/Footer";
@@ -13,8 +13,35 @@ import Contact from "../sections/Contact";
 import "./HomePage.css";
 
 function HomePage() {
+  const flowRef = useRef<HTMLDivElement>(null);
   const heroRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const flow = flowRef.current;
+
+    if (!flow) return;
+
+    const visualViewport = window.visualViewport;
+
+    const updateViewportHeight = () => {
+      const viewportHeight = visualViewport?.height ?? window.innerHeight;
+
+      flow.style.setProperty(
+        "--home-viewport-height",
+        `${Math.ceil(viewportHeight)}px`,
+      );
+    };
+
+    updateViewportHeight();
+    visualViewport?.addEventListener("resize", updateViewportHeight);
+    window.addEventListener("resize", updateViewportHeight);
+
+    return () => {
+      visualViewport?.removeEventListener("resize", updateViewportHeight);
+      window.removeEventListener("resize", updateViewportHeight);
+    };
+  }, []);
 
   useEffect(() => {
     if (window.location.hash) {
@@ -102,7 +129,7 @@ function HomePage() {
       <Navbar />
 
       <main id="main-content" tabIndex={-1}>
-        <div className="home-flow">
+        <div ref={flowRef} className="home-flow">
           <div ref={heroRef} className="home-hero-layer">
             <Hero />
           </div>

--- a/src/sections/Hero.css
+++ b/src/sections/Hero.css
@@ -11,8 +11,7 @@
   justify-content: center;
 
   max-width: var(--max-width);
-  min-height: 100svh;
-  min-height: 100dvh;
+  min-height: var(--home-viewport-height, 100svh);
 
   box-sizing: border-box;
 


### PR DESCRIPTION
## Summary

Follow-up to #80, #81, and #82

Sizes the homepage hero and spacer from Safari’s measured Visual Viewport rather than relying solely on CSS viewport units.

## Verification

- ESLint passed
- Production build passed
- Responsive Playwright checks: 12/12 passed