### PR TITLE
fix: account for Safari viewport offset

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,5 +1,6 @@
 .home-flow {
   --home-viewport-height: 100dvh;
+  --home-viewport-bottom: var(--home-viewport-height);
 
   position: relative;
 }
@@ -48,7 +49,7 @@
 }
 
 .home-hero-space {
-  height: var(--home-viewport-height, 100svh);
+  height: var(--home-viewport-bottom, 100svh);
 }
 
 .home-content {
@@ -163,7 +164,7 @@
   }
 
   .home-hero-space {
-    height: var(--home-viewport-height, 100svh);
+    height: var(--home-viewport-bottom, 100svh);
   }
 
   .home-content::before {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -23,23 +23,38 @@ function HomePage() {
     if (!flow) return;
 
     const visualViewport = window.visualViewport;
+    let frameId = 0;
 
     const updateViewportHeight = () => {
       const viewportHeight = visualViewport?.height ?? window.innerHeight;
+      const viewportBottom =
+        viewportHeight + (visualViewport?.offsetTop ?? 0);
 
       flow.style.setProperty(
         "--home-viewport-height",
         `${Math.ceil(viewportHeight)}px`,
       );
+      flow.style.setProperty(
+        "--home-viewport-bottom",
+        `${Math.ceil(viewportBottom)}px`,
+      );
+    };
+
+    const scheduleViewportUpdate = () => {
+      cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(updateViewportHeight);
     };
 
     updateViewportHeight();
-    visualViewport?.addEventListener("resize", updateViewportHeight);
-    window.addEventListener("resize", updateViewportHeight);
+    visualViewport?.addEventListener("resize", scheduleViewportUpdate);
+    visualViewport?.addEventListener("scroll", scheduleViewportUpdate);
+    window.addEventListener("resize", scheduleViewportUpdate);
 
     return () => {
-      visualViewport?.removeEventListener("resize", updateViewportHeight);
-      window.removeEventListener("resize", updateViewportHeight);
+      cancelAnimationFrame(frameId);
+      visualViewport?.removeEventListener("resize", scheduleViewportUpdate);
+      visualViewport?.removeEventListener("scroll", scheduleViewportUpdate);
+      window.removeEventListener("resize", scheduleViewportUpdate);
     };
   }, []);
 
@@ -77,7 +92,7 @@ function HomePage() {
 
     const updateHeroFade = () => {
       const contentTop = content.getBoundingClientRect().top;
-      const viewportHeight = window.innerHeight;
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
       const isMobile = window.innerWidth <= 768;
 
       const fadeStart = viewportHeight * (isMobile ? 0.95 : 0.9);

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -98,11 +98,23 @@ test.describe("accessibility", () => {
       experienceTop: document
         .querySelector("#experience")!
         .getBoundingClientRect().top,
+      measuredViewportBottom: Number.parseFloat(
+        getComputedStyle(document.querySelector(".home-flow")!).getPropertyValue(
+          "--home-viewport-bottom",
+        ),
+      ),
+      visualViewportBottom: Math.ceil(
+        (window.visualViewport?.height ?? window.innerHeight) +
+          (window.visualViewport?.offsetTop ?? 0),
+      ),
       viewportHeight: window.innerHeight,
     }));
 
+    expect(initialLayout.measuredViewportBottom).toBe(
+      initialLayout.visualViewportBottom,
+    );
     expect(initialLayout.experienceTop).toBeGreaterThanOrEqual(
-      initialLayout.viewportHeight,
+      initialLayout.measuredViewportBottom,
     );
 
     await page.evaluate(() => window.scrollTo(0, 48));


### PR DESCRIPTION
## Summary

Follow-up to #83.

Accounts for Safari’s Visual Viewport offset when positioning homepage content below the initial hero.

## Verification

- ESLint passed
- Production build passed
- Responsive Playwright checks: 9/9 passed