### PR TITLE
revert: remove ineffective Safari viewport instrumentation

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,7 +1,4 @@
 .home-flow {
-  --home-viewport-height: 100dvh;
-  --home-viewport-bottom: var(--home-viewport-height);
-
   position: relative;
 }
 
@@ -49,7 +46,8 @@
 }
 
 .home-hero-space {
-  height: var(--home-viewport-bottom, 100svh);
+  height: 100svh;
+  height: 100dvh;
 }
 
 .home-content {
@@ -164,7 +162,8 @@
   }
 
   .home-hero-space {
-    height: var(--home-viewport-bottom, 100svh);
+    height: 100svh;
+    height: 100dvh;
   }
 
   .home-content::before {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import Navbar from "../shared/Navbar";
 import Footer from "../shared/Footer";
@@ -13,50 +13,8 @@ import Contact from "../sections/Contact";
 import "./HomePage.css";
 
 function HomePage() {
-  const flowRef = useRef<HTMLDivElement>(null);
   const heroRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    const flow = flowRef.current;
-
-    if (!flow) return;
-
-    const visualViewport = window.visualViewport;
-    let frameId = 0;
-
-    const updateViewportHeight = () => {
-      const viewportHeight = visualViewport?.height ?? window.innerHeight;
-      const viewportBottom =
-        viewportHeight + (visualViewport?.offsetTop ?? 0);
-
-      flow.style.setProperty(
-        "--home-viewport-height",
-        `${Math.ceil(viewportHeight)}px`,
-      );
-      flow.style.setProperty(
-        "--home-viewport-bottom",
-        `${Math.ceil(viewportBottom)}px`,
-      );
-    };
-
-    const scheduleViewportUpdate = () => {
-      cancelAnimationFrame(frameId);
-      frameId = requestAnimationFrame(updateViewportHeight);
-    };
-
-    updateViewportHeight();
-    visualViewport?.addEventListener("resize", scheduleViewportUpdate);
-    visualViewport?.addEventListener("scroll", scheduleViewportUpdate);
-    window.addEventListener("resize", scheduleViewportUpdate);
-
-    return () => {
-      cancelAnimationFrame(frameId);
-      visualViewport?.removeEventListener("resize", scheduleViewportUpdate);
-      visualViewport?.removeEventListener("scroll", scheduleViewportUpdate);
-      window.removeEventListener("resize", scheduleViewportUpdate);
-    };
-  }, []);
 
   useEffect(() => {
     if (window.location.hash) {
@@ -92,7 +50,7 @@ function HomePage() {
 
     const updateHeroFade = () => {
       const contentTop = content.getBoundingClientRect().top;
-      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const viewportHeight = window.innerHeight;
       const isMobile = window.innerWidth <= 768;
 
       const fadeStart = viewportHeight * (isMobile ? 0.95 : 0.9);
@@ -144,7 +102,7 @@ function HomePage() {
       <Navbar />
 
       <main id="main-content" tabIndex={-1}>
-        <div ref={flowRef} className="home-flow">
+        <div className="home-flow">
           <div ref={heroRef} className="home-hero-layer">
             <Hero />
           </div>

--- a/src/sections/Hero.css
+++ b/src/sections/Hero.css
@@ -11,7 +11,8 @@
   justify-content: center;
 
   max-width: var(--max-width);
-  min-height: var(--home-viewport-height, 100svh);
+  min-height: 100svh;
+  min-height: 100dvh;
 
   box-sizing: border-box;
 

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -98,23 +98,11 @@ test.describe("accessibility", () => {
       experienceTop: document
         .querySelector("#experience")!
         .getBoundingClientRect().top,
-      measuredViewportBottom: Number.parseFloat(
-        getComputedStyle(document.querySelector(".home-flow")!).getPropertyValue(
-          "--home-viewport-bottom",
-        ),
-      ),
-      visualViewportBottom: Math.ceil(
-        (window.visualViewport?.height ?? window.innerHeight) +
-          (window.visualViewport?.offsetTop ?? 0),
-      ),
       viewportHeight: window.innerHeight,
     }));
 
-    expect(initialLayout.measuredViewportBottom).toBe(
-      initialLayout.visualViewportBottom,
-    );
     expect(initialLayout.experienceTop).toBeGreaterThanOrEqual(
-      initialLayout.measuredViewportBottom,
+      initialLayout.viewportHeight,
     );
 
     await page.evaluate(() => window.scrollTo(0, 48));


### PR DESCRIPTION
## Summary

Related to #80.

Removes the Visual Viewport instrumentation and offset calculations that did not resolve the Safari-specific hero issue.

Restores the simpler CSS `svh`/`dvh` baseline while the issue remains open for evidence-led investigation.

## Verification

- ESLint passed
- Production build passed
- Responsive Playwright checks: 9/9 passed