### PR TITLE
feat: return server-level 404 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ Preview the production build:
 npm run preview
 ```
 
+The production build generates static shells for every public route and a
+shared `404.html`, allowing Cloudflare Pages to preserve direct React route
+loading while returning a true `404` for invalid URLs. See the
+[server-level 404 decision record](docs/server-level-404s.md) for details.
+
 ---
 
 ## Testing

--- a/docs/server-level-404s.md
+++ b/docs/server-level-404s.md
@@ -1,0 +1,84 @@
+# Server-level 404 responses
+
+## Decision
+
+The portfolio uses build-time route shells and Cloudflare Pages' static
+`404.html` behaviour.
+
+The production build creates an `index.html` file for every public route in
+`sitemap.xml` and creates `dist/404.html` from the same React application shell.
+Cloudflare can therefore find a real file for every valid direct request and
+return `200`. Requests that do not match a generated file fall through to
+`404.html` and return `404` while React renders the appropriate contextual Not
+Found experience.
+
+The sitemap is the deployment contract for indexable public routes. Adding or
+removing an article, case study or other public route requires updating the
+sitemap. A future valid route that must not be indexed should be added to a
+separate route manifest rather than to the sitemap.
+
+## Current Cloudflare Pages behaviour
+
+Without a top-level `404.html`, Cloudflare Pages identifies the build as a
+single-page application and serves the root shell with `200` for unmatched
+paths. This allows React routes to load directly, but it also gives invalid
+paths a successful HTTP response.
+
+Adding only `404.html` would disable that automatic fallback and cause valid
+nested React routes to return `404`. Materialising the valid route shells
+preserves direct loading while enabling correct Not Found responses.
+
+## Alternatives considered
+
+### Pages Functions
+
+A catch-all Pages Function could classify paths and return the application
+shell with either `200` or `404`. It would introduce runtime execution, a route
+manifest inside server code and Functions usage for otherwise static requests.
+That cost is not justified by the portfolio's small, known route set.
+
+### Cloudflare Worker
+
+A Worker with static assets would provide the greatest routing control, but it
+would add deployment configuration and runtime infrastructure for behaviour
+that can be expressed during the existing static build.
+
+### Static 404 page without route shells
+
+This is the smallest configuration change, but valid articles, case studies
+and editorial routes would no longer load or refresh successfully when opened
+directly.
+
+## Trade-offs
+
+- The solution has no edge-runtime dependency or Function invocation cost.
+- Valid paths remain inspectable in the build output.
+- Route changes must remain aligned with the sitemap.
+- Every route shell contains the same initial HTML; React selects and renders
+  the visible page after loading.
+- Local development still uses Vite's SPA behaviour. HTTP status semantics are
+  verified against the generated production build, preview deployment and
+  production.
+
+## SEO behaviour
+
+Invalid routes retain the application's `noindex, follow` metadata and do not
+declare canonical URLs. A response-level `X-Robots-Tag` is not added because
+the existing HTML metadata expresses the indexing policy and the `404` status
+already communicates that the resource is unavailable.
+
+Lighthouse will reduce the SEO score of an error page because it is not
+indexable. That is expected and should not be treated as a regression.
+
+## Verification boundary
+
+The dependency-free local preview server mirrors the required static-host
+contract:
+
+- generated valid routes return `200`;
+- unknown routes return `404.html` with status `404`;
+- direct loading and refresh work for both states.
+
+Playwright runs against this server in local development and CI. Cloudflare
+preview and production remain the integration boundary for confirming the
+provider's actual routing and response headers.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -142,15 +142,22 @@ evidence.
 
 ### Local production build
 
-The default Playwright run builds the application and starts the Vite preview
-server automatically:
+The default Playwright run builds the application and starts the dependency-free
+static preview server automatically:
 
 ```bash
 npm run test:e2e
 ```
 
-This is the primary automated environment because it is deterministic and
-represents the generated application that will be deployed.
+This is the primary automated environment because it is deterministic,
+represents the generated application that will be deployed, and exercises the
+same `200` and `404` static-routing contract expected from Cloudflare Pages.
+
+The production build materialises every public route listed in `sitemap.xml`
+and generates a shared `404.html`. Update the sitemap whenever an indexable
+public route is added or removed. See
+[`server-level-404s.md`](./server-level-404s.md) for the architecture and its
+trade-offs.
 
 ### Cloudflare preview
 
@@ -432,9 +439,9 @@ and the quality of the evidence available.
 - Playwright currently runs Chromium only. Cross-browser visual review remains
   manual until Firefox or WebKit coverage provides enough value to justify its
   cost.
-- Cloudflare Pages currently serves the SPA shell with HTTP `200` for unknown
-  routes. React renders the correct error state, but true server-level `404`
-  responses are tracked separately.
+- Local automation verifies the generated static-routing contract. Cloudflare
+  preview and production checks remain necessary evidence that the hosting
+  platform serves the generated route shells and `404.html` as expected.
 - The suite does not validate third-party availability.
 - Automated visual comparison is intentionally excluded. Introduce it only for
   stable, high-value surfaces with a demonstrated regression history.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,13 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 export default defineConfig([
   globalIgnores(['dist']),
   {
+    files: ['scripts/**/*.mjs'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+  {
     files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/generate-route-shells.mjs",
     "lint": "eslint .",
-    "preview": "vite preview",
+    "preview": "node scripts/serve-built-site.mjs",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",

--- a/scripts/generate-route-shells.mjs
+++ b/scripts/generate-route-shells.mjs
@@ -1,0 +1,46 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const outputDirectory = path.join(projectRoot, "dist");
+const shell = await readFile(path.join(outputDirectory, "index.html"), "utf8");
+const sitemap = await readFile(path.join(outputDirectory, "sitemap.xml"), "utf8");
+
+const publicPaths = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map(
+  ([, location]) => new URL(location).pathname,
+);
+
+if (!publicPaths.includes("/")) {
+  throw new Error("The sitemap must include the homepage route.");
+}
+
+if (new Set(publicPaths).size !== publicPaths.length) {
+  throw new Error("The sitemap contains duplicate public routes.");
+}
+
+for (const publicPath of publicPaths) {
+  if (publicPath === "/") {
+    continue;
+  }
+
+  const routeSegments = publicPath.split("/").filter(Boolean);
+
+  if (routeSegments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error(`Unsafe public route in sitemap: ${publicPath}`);
+  }
+
+  const routeDirectory = path.join(outputDirectory, ...routeSegments);
+
+  await mkdir(routeDirectory, { recursive: true });
+  await writeFile(path.join(routeDirectory, "index.html"), shell);
+}
+
+await writeFile(path.join(outputDirectory, "404.html"), shell);
+
+console.log(
+  `Generated ${publicPaths.length - 1} nested route shells and 404.html.`,
+);

--- a/scripts/serve-built-site.mjs
+++ b/scripts/serve-built-site.mjs
@@ -1,0 +1,92 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const outputDirectory = path.join(projectRoot, "dist");
+
+const getArgument = (name, fallback) => {
+  const index = process.argv.indexOf(name);
+
+  return index === -1 ? fallback : process.argv[index + 1];
+};
+
+const hostname = getArgument("--host", "127.0.0.1");
+const port = Number(getArgument("--port", "4173"));
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".ico", "image/x-icon"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".txt", "text/plain; charset=utf-8"],
+  [".webp", "image/webp"],
+  [".woff2", "font/woff2"],
+  [".xml", "application/xml; charset=utf-8"],
+]);
+
+const findFile = async (pathname) => {
+  const decodedPath = decodeURIComponent(pathname);
+  const relativePath = decodedPath.replace(/^\/+/, "");
+  const candidates = relativePath
+    ? [relativePath, path.join(relativePath, "index.html")]
+    : ["index.html"];
+
+  for (const candidate of candidates) {
+    const absolutePath = path.resolve(outputDirectory, candidate);
+
+    if (!absolutePath.startsWith(`${outputDirectory}${path.sep}`)) {
+      continue;
+    }
+
+    try {
+      if ((await stat(absolutePath)).isFile()) {
+        return { absolutePath, status: 200 };
+      }
+    } catch {
+      // Try the next clean-URL candidate before returning the 404 shell.
+    }
+  }
+
+  return {
+    absolutePath: path.join(outputDirectory, "404.html"),
+    status: 404,
+  };
+};
+
+const server = http.createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url ?? "/", `http://${request.headers.host}`);
+    const { absolutePath, status } = await findFile(url.pathname);
+    const contentType =
+      contentTypes.get(path.extname(absolutePath)) ??
+      "application/octet-stream";
+
+    response.writeHead(status, {
+      "Cache-Control": "no-store",
+      "Content-Type": contentType,
+    });
+
+    if (request.method === "HEAD") {
+      response.end();
+      return;
+    }
+
+    createReadStream(absolutePath).pipe(response);
+  } catch (error) {
+    response.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+    response.end(error instanceof Error ? error.message : "Internal error");
+  }
+});
+
+server.listen(port, hostname, () => {
+  console.log(`Static preview available at http://${hostname}:${port}`);
+});

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -32,7 +32,9 @@ test.describe("error states", () => {
     test(`${errorState.name} provides a complete recovery experience`, async ({
       page,
     }) => {
-      await page.goto(errorState.path);
+      const response = await page.goto(errorState.path);
+
+      expect(response?.status()).toBe(404);
 
       await expect(page).toHaveTitle(errorState.title);
       await expect(
@@ -52,6 +54,16 @@ test.describe("error states", () => {
       await expect(page.getByRole("main")).toBeVisible();
       await expect(page.getByRole("contentinfo")).toBeVisible();
       await expect(page.getByRole("navigation")).toHaveCount(0);
+
+      const reloadResponse = await page.reload();
+
+      expect(reloadResponse?.status()).toBe(404);
+      await expect(
+        page.getByRole("heading", {
+          level: 1,
+          name: errorState.heading,
+        }),
+      ).toBeVisible();
 
       const recoveryLink = page.getByRole("link", {
         name: errorState.recoveryLabel,

--- a/tests/routes.spec.ts
+++ b/tests/routes.spec.ts
@@ -54,6 +54,16 @@ test.describe("core routes", () => {
 
       await expect(page.locator("h1")).toHaveCount(1);
 
+      const reloadResponse = await page.reload();
+
+      expect(reloadResponse?.status()).toBe(200);
+      await expect(
+        page.getByRole("heading", {
+          level: 1,
+          name: route.heading,
+        }),
+      ).toBeVisible();
+
       const horizontalOverflow = await page.evaluate(
         () => document.documentElement.scrollWidth - window.innerWidth,
       );


### PR DESCRIPTION
## Summary

- Generates static route shells for every public route in `sitemap.xml`.
- Adds a shared `404.html` so invalid URLs return HTTP `404`.
- Preserves direct loading and refresh behaviour for valid React routes.
- Retains contextual Not Found pages, recovery links and `noindex` metadata.
- Adds a local production server that reproduces the expected static-host response behaviour.
- Adds response-status and refresh coverage for valid and invalid routes.
- Documents the selected architecture, alternatives and trade-offs.

## Verification

- 108 Playwright tests passed.
- ESLint passed.
- Production build passed.
- Valid routes return `200` locally.
- Unknown top-level, article and case-study routes return `404` locally.
- Direct loading and refresh behaviour verified.

Closes #70