### PR TITLE
Fix iPhone Safari hero boundary

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -162,8 +162,8 @@
   }
 
   .home-hero-space {
-    height: 100svh;
-    height: 100dvh;
+    height: calc(100svh + 6rem);
+    height: calc(100dvh + 6rem);
   }
 
   .home-content::before {

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -73,7 +73,7 @@ test.describe("accessibility", () => {
       .locator("#experience")
       .evaluate((element) => element.getBoundingClientRect().top);
 
-    expect(experienceTop).toBeGreaterThanOrEqual(568);
+    expect(experienceTop).toBeGreaterThanOrEqual(568 + 96);
 
     const horizontalOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth - window.innerWidth,
@@ -102,7 +102,7 @@ test.describe("accessibility", () => {
     }));
 
     expect(initialLayout.experienceTop).toBeGreaterThanOrEqual(
-      initialLayout.viewportHeight,
+      initialLayout.viewportHeight + 96,
     );
 
     await page.evaluate(() => window.scrollTo(0, 48));


### PR DESCRIPTION
## Summary

Prevents the Experience section from appearing beneath Safari’s floating toolbar when the homepage initially loads on an iPhone.

## Changes

- Extends the mobile hero boundary to account for Safari’s viewport controls.
- Strengthens responsive regression coverage for the initial Experience position.

## Verification

- Confirmed on iPhone Safari using the original reproduction conditions.
- ESLint passed.
- Production build passed.
- Playwright passed: 108/108.

Closes #80 once and for all.