### PR TITLE
Feature/story 5 1 colour editorial markers

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -33,12 +33,7 @@
   background:
     radial-gradient(
       circle at 50% 46%,
-      color-mix(in srgb, var(--color-accent) 9%, transparent) 0,
-      transparent 38%
-    ),
-    radial-gradient(
-      circle at 50% 58%,
-      color-mix(in srgb, var(--color-heading) 4%, transparent) 0,
+      color-mix(in srgb, var(--color-accent) 5%, transparent) 0,
       transparent 34%
     );
 
@@ -186,6 +181,32 @@
     height: 3rem;
   }
 
+  .home-hero-layer::before {
+    background: radial-gradient(
+      circle at 50% 44%,
+      color-mix(in srgb, var(--color-accent) 5%, transparent) 0,
+      transparent 48%
+    );
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .home-hero-layer::before {
+    background:
+      radial-gradient(
+        circle at 50% 46%,
+        color-mix(in srgb, var(--color-accent) 9%, transparent) 0,
+        transparent 38%
+      ),
+      radial-gradient(
+        circle at 50% 58%,
+        color-mix(in srgb, var(--color-heading) 4%, transparent) 0,
+        transparent 34%
+      );
+  }
+}
+
+@media (prefers-color-scheme: dark) and (max-width: 768px) {
   .home-hero-layer::before {
     background: radial-gradient(
       circle at 50% 44%,

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -96,19 +96,29 @@
 }
 
 .home-section--evidence {
-  --home-section-space: 6.5rem;
+  --home-section-space: 3.5rem;
 }
 
 .home-section--principles {
-  --home-section-space: 5.5rem;
+  --home-section-space: 3rem;
 }
 
 .home-section--feature {
-  --home-section-space: 5rem;
+  --home-section-space: 2.5rem;
 }
 
 .home-section--compact {
-  --home-section-space: 4.5rem;
+  --home-section-space: 2.5rem;
+}
+
+.home-section + .home-section {
+  padding-top: 3rem;
+}
+
+#writing,
+#engineering-work,
+#contact {
+  border-top: 1px solid var(--color-border);
 }
 
 .home-section--closing {
@@ -140,19 +150,23 @@
   }
 
   .home-section--evidence {
-    --home-section-space: 4rem;
+    --home-section-space: 2rem;
   }
 
   .home-section--principles {
-    --home-section-space: 3.5rem;
+    --home-section-space: 1.75rem;
   }
 
   .home-section--feature {
-    --home-section-space: 3.25rem;
+    --home-section-space: 1.5rem;
   }
 
   .home-section--compact {
-    --home-section-space: 3rem;
+    --home-section-space: 1.5rem;
+  }
+
+  .home-section + .home-section {
+    padding-top: 2rem;
   }
 
   .home-section--closing {

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -12,8 +12,6 @@ function Contact() {
       id="contact"
       className="home-section home-section--closing contact"
     >
-      <p className="section-eyebrow">{contactContent.eyebrow}</p>
-
       <h2>{contactContent.heading}</h2>
 
       <p className="contact-copy">

--- a/src/sections/EngineeringWork.tsx
+++ b/src/sections/EngineeringWork.tsx
@@ -16,8 +16,6 @@ function EngineeringWork() {
       id="engineering-work"
       className="home-section home-section--compact engineering-work"
     >
-      <p className="section-eyebrow">Engineering work</p>
-
       <h2>{portfolio.title}</h2>
 
       <p className="engineering-work-description">{portfolio.description}</p>

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -10,9 +10,7 @@ function Experience() {
       id="experience"
       className="home-section home-section--evidence experience"
     >
-      <p className="section-eyebrow">Experience</p>
-
-      <h2>Quality engineering across products, teams and stages of growth.</h2>
+      <h2>Experience across products, teams and stages of growth.</h2>
 
       <div className="experience-list">
         {experiences.map((experience) => (

--- a/src/sections/FeaturedWriting.tsx
+++ b/src/sections/FeaturedWriting.tsx
@@ -17,9 +17,7 @@ function FeaturedWriting() {
       id="writing"
       className="home-section home-section--feature featured-writing"
     >
-      <p className="section-eyebrow">Writing</p>
-
-      <h2>Notes on testing, quality and engineering work.</h2>
+      <h2>Writing on testing, quality and engineering work.</h2>
 
       <article className="featured-writing-article">
         <p className="featured-writing-meta">

--- a/src/sections/Hero.css
+++ b/src/sections/Hero.css
@@ -32,6 +32,8 @@
 
   font-size: 0.95rem;
   letter-spacing: 0.065em;
+
+  color: var(--color-accent);
 }
 
 .hero .section-eyebrow::before,

--- a/src/sections/WorkingPrinciples.tsx
+++ b/src/sections/WorkingPrinciples.tsx
@@ -10,8 +10,6 @@ function WorkingPrinciples() {
       id="how-i-work"
       className="home-section home-section--principles working-principles"
     >
-      <p className="section-eyebrow">How I work</p>
-
       <h2>The work starts with context, questions and conversation.</h2>
 
       <div className="working-principles-grid">

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -6,5 +6,5 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 
-  color: var(--color-accent);
+  color: var(--color-editorial-marker);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -46,6 +46,11 @@
   /* Accent */
 
   --color-accent: #7b3a4d;
+  --color-editorial-marker: color-mix(
+    in srgb,
+    var(--color-accent) 58%,
+    var(--color-text)
+  );
 
   --accent-bg: rgba(123, 58, 77, 0.09);
   --accent-border: rgba(123, 58, 77, 0.38);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -31,9 +31,6 @@
 
   --transition: 200ms ease;
 
-  --shadow:
-    rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
-
   /* ========================================
      Colours
      ======================================== */
@@ -50,25 +47,6 @@
     in srgb,
     var(--color-accent) 58%,
     var(--color-text)
-  );
-
-  --accent-bg: rgba(123, 58, 77, 0.09);
-  --accent-border: rgba(123, 58, 77, 0.38);
-
-  /* Semantic */
-
-  --color-success: #6dbb75;
-
-  --color-success-soft: color-mix(
-    in srgb,
-    var(--color-success) 10%,
-    transparent
-  );
-
-  --color-success-border: color-mix(
-    in srgb,
-    var(--color-success) 30%,
-    transparent
   );
 
   /* Company */
@@ -100,27 +78,5 @@
     /* Accent */
 
     --color-accent: #d28a9d;
-
-    --accent-bg: rgba(210, 138, 157, 0.14);
-    --accent-border: rgba(210, 138, 157, 0.45);
-
-    /* Semantic */
-
-    --color-success: #7fcb87;
-
-    --color-success-soft: color-mix(
-      in srgb,
-      var(--color-success) 12%,
-      transparent
-    );
-
-    --color-success-border: color-mix(
-      in srgb,
-      var(--color-success) 35%,
-      transparent
-    );
-
-    --shadow:
-      rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
   }
 }


### PR DESCRIPTION
## Summary

Refines the portfolio’s colour roles and editorial hierarchy so the wine accent communicates identity and interaction without appearing across every homepage section.

## Changes

- Removes repeated homepage eyebrows.
- Reworks homepage headings to provide their own context.
- Adds restrained section boundaries and rebalances spacing.
- Keeps muted contextual markers on dedicated editorial pages.
- Refines the light-mode hero while preserving the richer dark-mode treatment.
- Removes unused colour, success and shadow tokens.

## Verification

- Editorial-marker contrast exceeds 7:1 in light and dark modes.
- Reviewed desktop, tablet, narrow mobile and landscape.
- Focused Playwright tests passed: 81/81.
- Complete Playwright suite passed: 114/114.
- ESLint passed.
- Production build passed.

Closes #90