### PR TITLE
feat: improve homepage continuation cue

### DIFF
--- a/src/sections/Hero.css
+++ b/src/sections/Hero.css
@@ -58,6 +58,10 @@
   animation-delay: 160ms;
 }
 
+.hero-continuation {
+  animation-delay: 240ms;
+}
+
 .hero h1 {
   margin: 0 0 var(--space-md);
 
@@ -76,6 +80,94 @@
   font-weight: 400;
   line-height: 1.35;
   letter-spacing: -0.15px;
+}
+
+.hero-continuation {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 44px;
+  min-height: 44px;
+
+  padding: 0;
+
+  color: var(--color-accent);
+  text-decoration: none;
+
+  pointer-events: auto;
+
+  transition: color var(--transition);
+}
+
+.hero-continuation-track {
+  display: block;
+  position: relative;
+
+  width: 8px;
+  height: 28px;
+}
+
+.hero-continuation-track::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+
+  width: 1px;
+
+  background: currentColor;
+  opacity: 0.32;
+
+  content: "";
+  transform: translateX(-50%);
+}
+
+.hero-continuation-track::after {
+  position: absolute;
+  top: 0;
+  left: 50%;
+
+  width: 5px;
+  height: 5px;
+
+  border-radius: 50%;
+  background: currentColor;
+
+  animation: hero-continuation-travel 2.8s ease-in-out infinite;
+  content: "";
+  transform: translateX(-50%);
+}
+
+.hero-continuation:hover {
+  color: var(--color-heading);
+}
+
+.hero-continuation:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 4px;
+
+  border-radius: 4px;
+}
+
+@keyframes hero-continuation-travel {
+  0%,
+  48%,
+  100% {
+    opacity: 0.5;
+    transform: translateX(-50%) translateY(0) scale(0.8);
+  }
+
+  70%,
+  78% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(23px) scale(1);
+  }
+
+  90% {
+    opacity: 0.65;
+    transform: translateX(-50%) translateY(0) scale(0.85);
+  }
 }
 
 @keyframes hero-reveal {
@@ -119,6 +211,7 @@
     font-size: 20px;
     line-height: 1.4;
   }
+
 }
 
 @media (max-height: 500px) and (orientation: landscape) {
@@ -144,5 +237,9 @@
     margin-bottom: 0;
 
     font-size: 18px;
+  }
+
+  .hero-continuation {
+    margin-top: 0.5rem;
   }
 }

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -13,6 +13,14 @@ function Hero() {
         I help product and engineering teams understand complex systems,
         uncover risk early and ship with confidence.
       </p>
+
+      <a
+        className="hero-continuation"
+        href="#experience"
+        aria-label="Continue to experience"
+      >
+        <span className="hero-continuation-track" aria-hidden="true" />
+      </a>
     </section>
   );
 }

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -32,6 +32,23 @@ const caseStudies = [
 ];
 
 test.describe("navigation", () => {
+  test("the hero continuation link reveals Experience", async ({ page }) => {
+    await page.goto("/");
+
+    const continuationLink = page.getByRole("link", {
+      name: "Continue to experience",
+    });
+
+    await expect(continuationLink).toBeVisible();
+    await expect(continuationLink).toHaveAttribute("href", "#experience");
+
+    await continuationLink.click();
+
+    await expect(page).toHaveURL(/#experience$/);
+    await expect(page.locator("#experience")).toBeInViewport();
+    await expect(page.locator(".site-header")).toHaveCSS("opacity", "1");
+  });
+
   test("primary navigation reaches each homepage section", async ({ page }) => {
     await page.goto("/");
     await page.evaluate(() => window.scrollTo(0, 48));


### PR DESCRIPTION
## Summary

Adds an interactive continuation cue beneath the homepage hero so visitors can discover the Experience section more naturally.

The cue uses a restrained track-and-dot animation, remains a standard `#experience` link and preserves an accessible descriptive name.

## Changes

- Add the homepage continuation link
- Animate the cue down, back up and then pause
- Preserve reduced-motion behaviour
- Add Playwright coverage for the continuation journey

Closes #91