### PR TITLE
feat: add webhook lab to engineering work

### DIFF
--- a/src/content/engineeringWork/index.ts
+++ b/src/content/engineeringWork/index.ts
@@ -8,8 +8,17 @@ export const engineeringWork: EngineeringProject[] = [
       "A small TypeScript system for investigating signed webhook delivery across an unreliable boundary.",
     summary:
       "It makes transient failures, retries, duplicates, invalid signatures and out-of-order events reproducible, with real HTTP integration tests and a documented account of the trade-offs.",
-    repositoryUrl: "https://github.com/smunyao/webhook-reliability-lab",
-    repositoryLabel: "View the lab on GitHub",
+    featured: true,
+    links: [
+      {
+        label: "View the lab on GitHub",
+        url: "https://github.com/smunyao/webhook-reliability-lab",
+      },
+      {
+        label: "View the v0.1.0 release",
+        url: "https://github.com/smunyao/webhook-reliability-lab/releases/tag/v0.1.0",
+      },
+    ],
     technologies: [
       "TypeScript",
       "Node.js",
@@ -23,11 +32,15 @@ export const engineeringWork: EngineeringProject[] = [
     slug: "portfolio",
     title: "This portfolio, treated as a product.",
     description:
-      "An evolving place for my experience, case studies and writing about software quality.",
+      "The portfolio itself, built and tested as an evolving product.",
     summary:
-      "Its repository shows the decisions behind accessible interactions, content-driven routes and metadata, responsive layouts and Playwright checks for critical journeys.",
-    repositoryUrl: "https://github.com/smunyao/kitaka-portfolio",
-    repositoryLabel: "View portfolio source on GitHub",
+      "Its source shows accessible interactions, content-driven routes and metadata, responsive layouts and Playwright coverage for critical journeys.",
+    links: [
+      {
+        label: "View portfolio source on GitHub",
+        url: "https://github.com/smunyao/kitaka-portfolio",
+      },
+    ],
     technologies: [
       "React",
       "TypeScript",

--- a/src/content/engineeringWork/index.ts
+++ b/src/content/engineeringWork/index.ts
@@ -2,6 +2,24 @@ import type { EngineeringProject } from "./types";
 
 export const engineeringWork: EngineeringProject[] = [
   {
+    slug: "webhook-reliability-lab",
+    title: "Webhook Reliability Lab",
+    description:
+      "A small TypeScript system for investigating signed webhook delivery across an unreliable boundary.",
+    summary:
+      "It makes transient failures, retries, duplicates, invalid signatures and out-of-order events reproducible, with real HTTP integration tests and a documented account of the trade-offs.",
+    repositoryUrl: "https://github.com/smunyao/webhook-reliability-lab",
+    repositoryLabel: "View the lab on GitHub",
+    technologies: [
+      "TypeScript",
+      "Node.js",
+      "Vitest",
+      "HTTP",
+      "HMAC",
+      "GitHub Actions",
+    ],
+  },
+  {
     slug: "portfolio",
     title: "This portfolio, treated as a product.",
     description:
@@ -9,6 +27,7 @@ export const engineeringWork: EngineeringProject[] = [
     summary:
       "Its repository shows the decisions behind accessible interactions, content-driven routes and metadata, responsive layouts and Playwright checks for critical journeys.",
     repositoryUrl: "https://github.com/smunyao/kitaka-portfolio",
+    repositoryLabel: "View portfolio source on GitHub",
     technologies: [
       "React",
       "TypeScript",

--- a/src/content/engineeringWork/index.ts
+++ b/src/content/engineeringWork/index.ts
@@ -9,14 +9,19 @@ export const engineeringWork: EngineeringProject[] = [
     summary:
       "It makes transient failures, retries, duplicates, invalid signatures and out-of-order events reproducible, with real HTTP integration tests and a documented account of the trade-offs.",
     featured: true,
+    evidence: {
+      label: "Example delivery",
+      items: [
+        { label: "Attempt 01", value: "503 · transient failure" },
+        { label: "Attempt 02", value: "503 · transient failure" },
+        { label: "Attempt 03", value: "200 · processed" },
+      ],
+      summary: "Duplicate acknowledged · 1 event processed",
+    },
     links: [
       {
         label: "View the lab on GitHub",
         url: "https://github.com/smunyao/webhook-reliability-lab",
-      },
-      {
-        label: "View the v0.1.0 release",
-        url: "https://github.com/smunyao/webhook-reliability-lab/releases/tag/v0.1.0",
       },
     ],
     technologies: [

--- a/src/content/engineeringWork/types.ts
+++ b/src/content/engineeringWork/types.ts
@@ -3,7 +3,10 @@ export type EngineeringProject = {
   title: string;
   description: string;
   summary: string;
-  repositoryUrl: string;
-  repositoryLabel: string;
+  featured?: boolean;
+  links: {
+    label: string;
+    url: string;
+  }[];
   technologies: string[];
 };

--- a/src/content/engineeringWork/types.ts
+++ b/src/content/engineeringWork/types.ts
@@ -4,6 +4,14 @@ export type EngineeringProject = {
   description: string;
   summary: string;
   featured?: boolean;
+  evidence?: {
+    label: string;
+    items: {
+      label: string;
+      value: string;
+    }[];
+    summary: string;
+  };
   links: {
     label: string;
     url: string;

--- a/src/content/engineeringWork/types.ts
+++ b/src/content/engineeringWork/types.ts
@@ -4,5 +4,6 @@ export type EngineeringProject = {
   description: string;
   summary: string;
   repositoryUrl: string;
+  repositoryLabel: string;
   technologies: string[];
 };

--- a/src/sections/EngineeringWork.css
+++ b/src/sections/EngineeringWork.css
@@ -3,17 +3,41 @@
 }
 
 .engineering-work-list {
-  max-width: var(--content-width);
+  display: grid;
+
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+
+  gap: clamp(2rem, 4vw, 3rem);
+
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .engineering-work-item {
-  padding: var(--space-lg) 0;
-
-  border-top: 1px solid var(--color-border);
+  padding: var(--space-lg) 0 var(--space-xl);
 }
 
-.engineering-work-item:last-child {
-  padding-bottom: 0;
+.engineering-work-item + .engineering-work-item {
+  padding-left: clamp(2rem, 4vw, 3rem);
+
+  border-left: 1px solid var(--color-border);
+}
+
+.engineering-work-item--featured {
+  position: relative;
+}
+
+.engineering-work-item--featured::before {
+  position: absolute;
+  top: -1px;
+  left: 0;
+
+  width: 4rem;
+  height: 2px;
+
+  background: var(--color-accent);
+
+  content: "";
 }
 
 .engineering-work-item h3 {
@@ -25,6 +49,14 @@
   font-weight: 500;
   line-height: 1.35;
   letter-spacing: -0.25px;
+}
+
+.engineering-work-item--featured h3 {
+  max-width: 42rem;
+
+  font-size: 1.75rem;
+  line-height: 1.25;
+  letter-spacing: -0.4px;
 }
 
 .engineering-work-description,
@@ -56,6 +88,13 @@
 
 .engineering-work-technologies li:not(:last-child)::after {
   content: " ·";
+}
+
+.engineering-work-links {
+  display: flex;
+  flex-wrap: wrap;
+
+  gap: 0.8rem 1.25rem;
 }
 
 .engineering-work-link {
@@ -96,12 +135,30 @@
 }
 
 @media (max-width: 768px) {
+  .engineering-work-list {
+    grid-template-columns: minmax(0, 1fr);
+
+    gap: 0;
+  }
+
   .engineering-work-item {
-    padding: var(--space-md) 0;
+    padding: var(--space-md) 0 var(--space-lg);
+  }
+
+  .engineering-work-item + .engineering-work-item {
+    padding-top: var(--space-lg);
+    padding-left: 0;
+
+    border-top: 1px solid var(--color-border);
+    border-left: 0;
   }
 
   .engineering-work-item h3 {
     font-size: 1.2rem;
+  }
+
+  .engineering-work-item--featured h3 {
+    font-size: 1.45rem;
   }
 
   .engineering-work-description,

--- a/src/sections/EngineeringWork.css
+++ b/src/sections/EngineeringWork.css
@@ -90,6 +90,73 @@
   content: " ·";
 }
 
+.engineering-work-evidence {
+  max-width: 32rem;
+
+  margin: 0 0 var(--space-md);
+  padding: 1rem 1.1rem;
+
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+
+  background: color-mix(in srgb, var(--color-border) 14%, transparent);
+
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+}
+
+.engineering-work-evidence figcaption {
+  margin-bottom: 0.8rem;
+
+  color: var(--color-heading);
+
+  font-family: "Geist Variable", system-ui, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.engineering-work-evidence ol {
+  display: grid;
+
+  gap: 0.4rem;
+
+  margin: 0;
+  padding: 0;
+
+  list-style: none;
+
+  color: var(--color-text);
+
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.engineering-work-evidence li {
+  display: grid;
+
+  grid-template-columns: 6.5rem minmax(0, 1fr);
+
+  gap: 0.75rem;
+}
+
+.engineering-work-evidence li span:first-child {
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+
+.engineering-work-evidence p {
+  margin: 0.8rem 0 0;
+  padding-top: 0.8rem;
+
+  border-top: 1px solid var(--color-border);
+
+  color: var(--color-heading);
+
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
 .engineering-work-links {
   display: flex;
   flex-wrap: wrap;
@@ -159,6 +226,10 @@
 
   .engineering-work-item--featured h3 {
     font-size: 1.45rem;
+  }
+
+  .engineering-work-evidence {
+    max-width: 100%;
   }
 
   .engineering-work-description,

--- a/src/sections/EngineeringWork.css
+++ b/src/sections/EngineeringWork.css
@@ -1,5 +1,30 @@
-.engineering-work h2 {
+.engineering-work > h2 {
+  margin-bottom: var(--space-md);
+}
+
+.engineering-work-list {
+  max-width: var(--content-width);
+}
+
+.engineering-work-item {
+  padding: var(--space-lg) 0;
+
+  border-top: 1px solid var(--color-border);
+}
+
+.engineering-work-item:last-child {
+  padding-bottom: 0;
+}
+
+.engineering-work-item h3 {
+  max-width: 38rem;
+
   margin-bottom: var(--space-sm);
+
+  font-size: 1.35rem;
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: -0.25px;
 }
 
 .engineering-work-description,
@@ -71,6 +96,14 @@
 }
 
 @media (max-width: 768px) {
+  .engineering-work-item {
+    padding: var(--space-md) 0;
+  }
+
+  .engineering-work-item h3 {
+    font-size: 1.2rem;
+  }
+
   .engineering-work-description,
   .engineering-work-summary {
     font-size: 1rem;

--- a/src/sections/EngineeringWork.tsx
+++ b/src/sections/EngineeringWork.tsx
@@ -16,7 +16,10 @@ function EngineeringWork() {
 
       <div className="engineering-work-list">
         {engineeringWork.map((project) => (
-          <article key={project.slug} className="engineering-work-item">
+          <article
+            key={project.slug}
+            className={`engineering-work-item${project.featured ? " engineering-work-item--featured" : ""}`}
+          >
             <h3>{project.title}</h3>
 
             <p className="engineering-work-description">
@@ -34,20 +37,25 @@ function EngineeringWork() {
               ))}
             </ul>
 
-            <a
-              className="engineering-work-link"
-              href={project.repositoryUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span>{project.repositoryLabel}</span>
-              <span
-                className="engineering-work-link-arrow"
-                aria-hidden="true"
-              >
-                ↗
-              </span>
-            </a>
+            <div className="engineering-work-links">
+              {project.links.map((link) => (
+                <a
+                  key={link.url}
+                  className="engineering-work-link"
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span>{link.label}</span>
+                  <span
+                    className="engineering-work-link-arrow"
+                    aria-hidden="true"
+                  >
+                    ↗
+                  </span>
+                </a>
+              ))}
+            </div>
           </article>
         ))}
       </div>

--- a/src/sections/EngineeringWork.tsx
+++ b/src/sections/EngineeringWork.tsx
@@ -37,6 +37,23 @@ function EngineeringWork() {
               ))}
             </ul>
 
+            {project.evidence && (
+              <figure className="engineering-work-evidence">
+                <figcaption>{project.evidence.label}</figcaption>
+
+                <ol>
+                  {project.evidence.items.map((item) => (
+                    <li key={item.label}>
+                      <span>{item.label}</span>
+                      <span>{item.value}</span>
+                    </li>
+                  ))}
+                </ol>
+
+                <p>{project.evidence.summary}</p>
+              </figure>
+            )}
+
             <div className="engineering-work-links">
               {project.links.map((link) => (
                 <a

--- a/src/sections/EngineeringWork.tsx
+++ b/src/sections/EngineeringWork.tsx
@@ -3,11 +3,7 @@ import { engineeringWork } from "../content/engineeringWork";
 import "./EngineeringWork.css";
 
 function EngineeringWork() {
-  const portfolio = engineeringWork.find(
-    (project) => project.slug === "portfolio",
-  );
-
-  if (!portfolio) {
+  if (engineeringWork.length === 0) {
     return null;
   }
 
@@ -16,34 +12,45 @@ function EngineeringWork() {
       id="engineering-work"
       className="home-section home-section--compact engineering-work"
     >
-      <h2>{portfolio.title}</h2>
+      <h2>Engineering work</h2>
 
-      <p className="engineering-work-description">{portfolio.description}</p>
+      <div className="engineering-work-list">
+        {engineeringWork.map((project) => (
+          <article key={project.slug} className="engineering-work-item">
+            <h3>{project.title}</h3>
 
-      <p className="engineering-work-summary">{portfolio.summary}</p>
+            <p className="engineering-work-description">
+              {project.description}
+            </p>
 
-      <ul
-        className="engineering-work-technologies"
-        aria-label="Portfolio technologies"
-      >
-        {portfolio.technologies.map((technology) => (
-          <li key={technology}>{technology}</li>
+            <p className="engineering-work-summary">{project.summary}</p>
+
+            <ul
+              className="engineering-work-technologies"
+              aria-label={`${project.title} technologies`}
+            >
+              {project.technologies.map((technology) => (
+                <li key={technology}>{technology}</li>
+              ))}
+            </ul>
+
+            <a
+              className="engineering-work-link"
+              href={project.repositoryUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span>{project.repositoryLabel}</span>
+              <span
+                className="engineering-work-link-arrow"
+                aria-hidden="true"
+              >
+                ↗
+              </span>
+            </a>
+          </article>
         ))}
-      </ul>
-
-      {portfolio.repositoryUrl && (
-        <a
-          className="engineering-work-link"
-          href={portfolio.repositoryUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span>View the source on GitHub</span>
-          <span className="engineering-work-link-arrow" aria-hidden="true">
-            ↗
-          </span>
-        </a>
-      )}
+      </div>
     </section>
   );
 }

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -342,15 +342,15 @@ test.describe("accessibility", () => {
     await page.setViewportSize({ width: 320, height: 720 });
     await page.goto("/#engineering-work");
 
-    const repositoryLink = page.getByRole("link", {
-      name: "View the source on GitHub",
+    const labLink = page.getByRole("link", {
+      name: "View the lab on GitHub",
     });
 
-    await repositoryLink.focus();
+    await labLink.focus();
 
-    await expect(repositoryLink).toBeFocused();
-    await expect(repositoryLink).toHaveCSS("outline-style", "solid");
-    await expect(repositoryLink).toHaveCSS("outline-width", "3px");
+    await expect(labLink).toBeFocused();
+    await expect(labLink).toHaveCSS("outline-style", "solid");
+    await expect(labLink).toHaveCSS("outline-width", "3px");
 
     const horizontalOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth - window.innerWidth,

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -238,28 +238,56 @@ test.describe("navigation", () => {
     }
   });
 
-  test("engineering work links to the inspectable portfolio repository", async ({
+  test("engineering work links to each inspectable repository", async ({
     page,
   }) => {
     await page.goto("/#engineering-work");
 
     const engineeringWork = page.locator("#engineering-work");
-    const repositoryLink = engineeringWork.getByRole("link", {
-      name: "View the source on GitHub",
-    });
 
     await expect(
       engineeringWork.getByRole("heading", {
         level: 2,
+        name: "Engineering work",
+      }),
+    ).toBeVisible();
+
+    const labLink = engineeringWork.getByRole("link", {
+      name: "View the lab on GitHub",
+    });
+    const portfolioLink = engineeringWork.getByRole("link", {
+      name: "View portfolio source on GitHub",
+    });
+
+    await expect(
+      engineeringWork.getByRole("heading", {
+        level: 3,
+        name: "Webhook Reliability Lab",
+      }),
+    ).toBeVisible();
+    await expect(
+      engineeringWork.getByRole("heading", {
+        level: 3,
         name: "This portfolio, treated as a product.",
       }),
     ).toBeVisible();
-    await expect(repositoryLink).toHaveAttribute(
+
+    await expect(labLink).toHaveAttribute(
+      "href",
+      "https://github.com/smunyao/webhook-reliability-lab",
+    );
+    await expect(portfolioLink).toHaveAttribute(
       "href",
       "https://github.com/smunyao/kitaka-portfolio",
     );
-    await expect(repositoryLink).toHaveAttribute("target", "_blank");
-    await expect(repositoryLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    for (const repositoryLink of [labLink, portfolioLink]) {
+      await expect(repositoryLink).toHaveAttribute("target", "_blank");
+      await expect(repositoryLink).toHaveAttribute(
+        "rel",
+        "noopener noreferrer",
+      );
+    }
   });
 
   for (const caseStudy of caseStudies) {

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -258,9 +258,6 @@ test.describe("navigation", () => {
     const portfolioLink = engineeringWork.getByRole("link", {
       name: "View portfolio source on GitHub",
     });
-    const releaseLink = engineeringWork.getByRole("link", {
-      name: "View the v0.1.0 release",
-    });
 
     await expect(
       engineeringWork.getByRole("heading", {
@@ -283,12 +280,12 @@ test.describe("navigation", () => {
       "href",
       "https://github.com/smunyao/kitaka-portfolio",
     );
-    await expect(releaseLink).toHaveAttribute(
-      "href",
-      "https://github.com/smunyao/webhook-reliability-lab/releases/tag/v0.1.0",
-    );
 
-    for (const repositoryLink of [labLink, releaseLink, portfolioLink]) {
+    await expect(
+      engineeringWork.getByText("Duplicate acknowledged · 1 event processed"),
+    ).toBeVisible();
+
+    for (const repositoryLink of [labLink, portfolioLink]) {
       await expect(repositoryLink).toHaveAttribute("target", "_blank");
       await expect(repositoryLink).toHaveAttribute(
         "rel",

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -258,6 +258,9 @@ test.describe("navigation", () => {
     const portfolioLink = engineeringWork.getByRole("link", {
       name: "View portfolio source on GitHub",
     });
+    const releaseLink = engineeringWork.getByRole("link", {
+      name: "View the v0.1.0 release",
+    });
 
     await expect(
       engineeringWork.getByRole("heading", {
@@ -280,8 +283,12 @@ test.describe("navigation", () => {
       "href",
       "https://github.com/smunyao/kitaka-portfolio",
     );
+    await expect(releaseLink).toHaveAttribute(
+      "href",
+      "https://github.com/smunyao/webhook-reliability-lab/releases/tag/v0.1.0",
+    );
 
-    for (const repositoryLink of [labLink, portfolioLink]) {
+    for (const repositoryLink of [labLink, releaseLink, portfolioLink]) {
       await expect(repositoryLink).toHaveAttribute("target", "_blank");
       await expect(repositoryLink).toHaveAttribute(
         "rel",


### PR DESCRIPTION
## Summary

Adds the [Webhook Reliability Lab](https://github.com/smunyao/webhook-reliability-lab) as a second piece of inspectable engineering work and evolves the homepage section to support multiple projects.

## Changes

- Add the Webhook Reliability Lab project
- Link to its public repository and [`v0.1.0` release](https://github.com/smunyao/webhook-reliability-lab/releases/tag/v0.1.0)
- Restructure Engineering work as a two-project editorial list
- Preserve descriptive external links and technology context
- Update navigation coverage for both repositories

## Verification

- [x] ESLint
- [x] Production build
- [x] Desktop and mobile visual review
- [x] No horizontal overflow
- [x] Focused Playwright tests across desktop, tablet and mobile
- [x] Webhook lab: 13 automated tests
- [x] Webhook lab GitHub Actions
- [x] Portfolio GitHub Actions
- [x] Cloudflare preview

Closes #93