### PR TITLE
fix: align engineering project link labels

### DIFF
--- a/src/content/engineeringWork/index.ts
+++ b/src/content/engineeringWork/index.ts
@@ -20,7 +20,8 @@ export const engineeringWork: EngineeringProject[] = [
     },
     links: [
       {
-        label: "View the lab on GitHub",
+        label: "View repository on GitHub",
+        ariaLabel: "View Webhook Reliability Lab repository on GitHub",
         url: "https://github.com/smunyao/webhook-reliability-lab",
       },
     ],
@@ -42,7 +43,8 @@ export const engineeringWork: EngineeringProject[] = [
       "Its source shows accessible interactions, content-driven routes and metadata, responsive layouts and Playwright coverage for critical journeys.",
     links: [
       {
-        label: "View portfolio source on GitHub",
+        label: "View repository on GitHub",
+        ariaLabel: "View portfolio repository on GitHub",
         url: "https://github.com/smunyao/kitaka-portfolio",
       },
     ],

--- a/src/content/engineeringWork/types.ts
+++ b/src/content/engineeringWork/types.ts
@@ -14,6 +14,7 @@ export type EngineeringProject = {
   };
   links: {
     label: string;
+    ariaLabel: string;
     url: string;
   }[];
   technologies: string[];

--- a/src/sections/EngineeringWork.tsx
+++ b/src/sections/EngineeringWork.tsx
@@ -60,6 +60,7 @@ function EngineeringWork() {
                   key={link.url}
                   className="engineering-work-link"
                   href={link.url}
+                  aria-label={link.ariaLabel}
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -343,7 +343,7 @@ test.describe("accessibility", () => {
     await page.goto("/#engineering-work");
 
     const labLink = page.getByRole("link", {
-      name: "View the lab on GitHub",
+      name: "View Webhook Reliability Lab repository on GitHub",
     });
 
     await labLink.focus();

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -253,10 +253,10 @@ test.describe("navigation", () => {
     ).toBeVisible();
 
     const labLink = engineeringWork.getByRole("link", {
-      name: "View the lab on GitHub",
+      name: "View Webhook Reliability Lab repository on GitHub",
     });
     const portfolioLink = engineeringWork.getByRole("link", {
-      name: "View portfolio source on GitHub",
+      name: "View portfolio repository on GitHub",
     });
 
     await expect(


### PR DESCRIPTION
## Summary

Aligns both Engineering work links to use “View repository on GitHub” while retaining project-specific accessible names.

Follow-up to #102 and #93