### PR TITLE
fix: remove employment periods from case studies

### DIFF
--- a/src/content/caseStudies/chiliPiper.ts
+++ b/src/content/caseStudies/chiliPiper.ts
@@ -7,7 +7,6 @@ export const chiliPiperCaseStudy: CaseStudy = {
   companyUrl: "https://www.chilipiper.com",
 
   role: "QA Analyst",
-  period: "2022–2024",
 
   title: "Quality begins with understanding the system",
 

--- a/src/content/caseStudies/harvest.ts
+++ b/src/content/caseStudies/harvest.ts
@@ -7,7 +7,6 @@ export const harvestCaseStudy: CaseStudy = {
   companyUrl: "https://www.getharvest.com",
 
   role: "Quality Engineer",
-  period: "2019–2025",
 
   title: "Building confidence across a connected product ecosystem",
 

--- a/src/content/caseStudies/sitemate.ts
+++ b/src/content/caseStudies/sitemate.ts
@@ -7,7 +7,6 @@ export const sitemateCaseStudy: CaseStudy = {
   companyUrl: "https://sitemate.com",
 
   role: "QA Engineer and Lead",
-  period: "2019–2022",
 
   title: "Building quality from the ground up",
 

--- a/src/content/caseStudies/types.ts
+++ b/src/content/caseStudies/types.ts
@@ -5,7 +5,6 @@ export interface CaseStudy {
   companyUrl: string;
 
   role: string;
-  period: string;
 
   title: string;
   summary: string;

--- a/src/shared/CaseStudyLayout.css
+++ b/src/shared/CaseStudyLayout.css
@@ -145,7 +145,8 @@
 
   padding-bottom: 0.2rem;
 
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--company-accent) 65%, transparent);
 
   color: var(--color-heading);
   text-decoration: none;

--- a/src/shared/CaseStudyLayout.css
+++ b/src/shared/CaseStudyLayout.css
@@ -104,16 +104,6 @@
   line-height: 1.55;
 }
 
-.case-study-company p + p {
-  margin-top: 0.2rem;
-}
-
-.case-study-company p:last-child {
-  color: color-mix(in srgb, var(--color-text) 72%, transparent);
-
-  font-size: 0.85rem;
-}
-
 .case-study-sidebar-section {
   padding-top: var(--space-md);
 

--- a/src/shared/CaseStudyLayout.css
+++ b/src/shared/CaseStudyLayout.css
@@ -145,8 +145,7 @@
 
   padding-bottom: 0.2rem;
 
-  border-bottom: 1px solid
-    color-mix(in srgb, var(--company-accent) 65%, transparent);
+  border-bottom: 1px solid var(--color-border);
 
   color: var(--color-heading);
   text-decoration: none;

--- a/src/shared/CaseStudyLayout.css
+++ b/src/shared/CaseStudyLayout.css
@@ -147,7 +147,7 @@
 
   border-bottom: 1px solid var(--color-border);
 
-  color: color-mix(in srgb, var(--color-text) 72%, transparent);
+  color: var(--color-heading);
   text-decoration: none;
 
   font-size: 0.9rem;

--- a/src/shared/CaseStudyLayout.css
+++ b/src/shared/CaseStudyLayout.css
@@ -147,7 +147,7 @@
 
   border-bottom: 1px solid var(--color-border);
 
-  color: var(--color-heading);
+  color: color-mix(in srgb, var(--color-text) 72%, transparent);
   text-decoration: none;
 
   font-size: 0.9rem;

--- a/src/shared/CaseStudyLayout.tsx
+++ b/src/shared/CaseStudyLayout.tsx
@@ -44,7 +44,6 @@ function CaseStudyDetails({
         <div className="case-study-company">
           <h2>{caseStudy.company}</h2>
           <p>{caseStudy.role}</p>
-          <p>{caseStudy.period}</p>
         </div>
       )}
 
@@ -97,10 +96,7 @@ function CaseStudyLayout({ caseStudy, nextCaseStudy }: CaseStudyLayoutProps) {
       </header>
 
       <div className="case-study-mobile-context">
-        <p className="case-study-mobile-meta">
-          <span>{caseStudy.role}</span> <span aria-hidden="true">·</span>{" "}
-          <span>{caseStudy.period}</span>
-        </p>
+        <p className="case-study-mobile-meta">{caseStudy.role}</p>
 
         <details
           className="case-study-mobile-details"

--- a/src/shared/CaseStudyLayout.tsx
+++ b/src/shared/CaseStudyLayout.tsx
@@ -150,6 +150,7 @@ function CaseStudyLayout({ caseStudy, nextCaseStudy }: CaseStudyLayoutProps) {
         nextTo={`/case-studies/${nextCaseStudy.slug}`}
         nextLabel="Another case study"
         nextTitle={`${nextCaseStudy.company} — ${nextCaseStudy.title}`}
+        nextAccent={nextCaseStudy.slug}
         ariaLabel="Continue exploring case studies"
       />
     </article>

--- a/src/shared/ContentEndNavigation.css
+++ b/src/shared/ContentEndNavigation.css
@@ -39,6 +39,7 @@
 
 .content-end-navigation-next {
   --content-end-next-accent: var(--color-accent);
+  --content-end-link-accent: var(--content-end-next-accent);
 
   display: flex;
   flex-direction: column;
@@ -111,12 +112,7 @@
 
 .content-end-navigation a:hover .content-end-navigation-arrow,
 .content-end-navigation a:focus-visible .content-end-navigation-arrow {
-  color: var(--color-accent);
-}
-
-.content-end-navigation-next:hover .content-end-navigation-arrow,
-.content-end-navigation-next:focus-visible .content-end-navigation-arrow {
-  color: var(--content-end-next-accent);
+  color: var(--content-end-link-accent, var(--color-accent));
 }
 
 .content-end-navigation-back:hover .content-end-navigation-arrow,

--- a/src/shared/ContentEndNavigation.css
+++ b/src/shared/ContentEndNavigation.css
@@ -38,6 +38,8 @@
 }
 
 .content-end-navigation-next {
+  --content-end-next-accent: var(--color-accent);
+
   display: flex;
   flex-direction: column;
   grid-column: 2;
@@ -48,6 +50,18 @@
   max-width: 24rem;
 
   text-align: right;
+}
+
+.content-end-navigation-next[data-accent="harvest"] {
+  --content-end-next-accent: var(--company-harvest);
+}
+
+.content-end-navigation-next[data-accent="chili-piper"] {
+  --content-end-next-accent: var(--company-chili-piper);
+}
+
+.content-end-navigation-next[data-accent="sitemate"] {
+  --content-end-next-accent: var(--company-sitemate);
 }
 
 .content-end-navigation-label {
@@ -90,7 +104,7 @@
   .content-end-navigation-title
   .content-end-navigation-arrow {
   text-decoration: underline;
-  text-decoration-color: var(--color-accent);
+  text-decoration-color: var(--content-end-next-accent);
   text-decoration-thickness: 1px;
   text-underline-offset: 0.16em;
 }

--- a/src/shared/ContentEndNavigation.css
+++ b/src/shared/ContentEndNavigation.css
@@ -114,6 +114,11 @@
   color: var(--color-accent);
 }
 
+.content-end-navigation-next:hover .content-end-navigation-arrow,
+.content-end-navigation-next:focus-visible .content-end-navigation-arrow {
+  color: var(--content-end-next-accent);
+}
+
 .content-end-navigation-back:hover .content-end-navigation-arrow,
 .content-end-navigation-back:focus-visible .content-end-navigation-arrow {
   transform: translateX(-2px);

--- a/src/shared/ContentEndNavigation.tsx
+++ b/src/shared/ContentEndNavigation.tsx
@@ -8,6 +8,7 @@ interface ContentEndNavigationProps {
   nextTo: string;
   nextLabel: string;
   nextTitle: string;
+  nextAccent?: string;
   ariaLabel: string;
 }
 
@@ -17,11 +18,16 @@ function ContentEndNavigation({
   nextTo,
   nextLabel,
   nextTitle,
+  nextAccent,
   ariaLabel,
 }: ContentEndNavigationProps) {
   return (
     <nav className="content-end-navigation" aria-label={ariaLabel}>
-      <Link className="content-end-navigation-next" to={nextTo}>
+      <Link
+        className="content-end-navigation-next"
+        data-accent={nextAccent}
+        to={nextTo}
+      >
         <span className="content-end-navigation-label">{nextLabel}</span>
         <span className="content-end-navigation-title">
           {nextTitle}

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -249,9 +249,6 @@ test.describe("accessibility", () => {
     await expect(
       mobileContext.getByText("QA Engineer and Lead", { exact: true }),
     ).toBeVisible();
-    await expect(
-      mobileContext.getByText("2019–2022", { exact: true }),
-    ).toBeVisible();
 
     const details = page.locator(".case-study-mobile-details");
     const summary = page.getByText("Product and focus details", {


### PR DESCRIPTION
## Summary

- Remove employment periods from the Harvest, Chili Piper and Sitemate case-study content and layouts.
- Simplify mobile case-study metadata to show the role without an obsolete separator.
- Apply each destination company’s established accent colour to the underline and arrow in the bottom case-study continuation link.
- Keep article continuations and external company links using their existing styling.
- Remove the low-value automated assertion for a specific employment period.

## Verification

- ESLint passed.
- Production build passed.
- Playwright passed: 222 tests across desktop, tablet and mobile.