### PR TITLE
Feature/story 7 1 homepage evidence hierarchy

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -107,8 +107,8 @@ function HomePage() {
 
           <div ref={contentRef} className="home-content">
             <Experience />
-            <EngineeringWork />
             <WorkingPrinciples />
+            <EngineeringWork />
             <FeaturedWriting />
             <Contact />
           </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -107,9 +107,9 @@ function HomePage() {
 
           <div ref={contentRef} className="home-content">
             <Experience />
+            <EngineeringWork />
             <WorkingPrinciples />
             <FeaturedWriting />
-            <EngineeringWork />
             <Contact />
           </div>
         </div>

--- a/src/shared/Navbar.tsx
+++ b/src/shared/Navbar.tsx
@@ -7,7 +7,6 @@ import "./Navbar.css";
 const SECTION_IDS = [
   "experience",
   "engineering-work",
-  "how-i-work",
   "writing",
   "contact",
 ];

--- a/src/shared/Navbar.tsx
+++ b/src/shared/Navbar.tsx
@@ -4,7 +4,13 @@ import { useActiveSection } from "../hooks/useActiveSection";
 
 import "./Navbar.css";
 
-const SECTION_IDS = ["experience", "how-i-work", "writing", "contact"];
+const SECTION_IDS = [
+  "experience",
+  "engineering-work",
+  "how-i-work",
+  "writing",
+  "contact",
+];
 
 function Navbar() {
   const activeSection = useActiveSection(SECTION_IDS);
@@ -150,14 +156,18 @@ function Navbar() {
 
             <li>
               <a
-                href="#how-i-work"
+                href="#engineering-work"
                 onClick={closeMenu}
-                className={activeSection === "how-i-work" ? "active" : ""}
+                className={
+                  activeSection === "engineering-work" ? "active" : ""
+                }
                 aria-current={
-                  activeSection === "how-i-work" ? "location" : undefined
+                  activeSection === "engineering-work"
+                    ? "location"
+                    : undefined
                 }
               >
-                How I work
+                Engineering
               </a>
             </li>
 

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -173,6 +173,24 @@ test.describe("navigation", () => {
     await expect(page.locator(".site-header")).toHaveCSS("opacity", "1");
   });
 
+  test("homepage evidence follows the agreed narrative order", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const sectionOrder = await page
+      .locator(".home-content > section")
+      .evaluateAll((sections) => sections.map((section) => section.id));
+
+    expect(sectionOrder).toEqual([
+      "experience",
+      "how-i-work",
+      "engineering-work",
+      "writing",
+      "contact",
+    ]);
+  });
+
   test("primary navigation reaches each homepage section", async ({ page }) => {
     await page.goto("/");
     await page.evaluate(() => window.scrollTo(0, 48));

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 const primaryNavigation = [
   { name: "Experience", hash: "#experience" },
-  { name: "How I work", hash: "#how-i-work" },
+  { name: "Engineering", hash: "#engineering-work" },
   { name: "Writing", hash: "#writing" },
   { name: "Contact", hash: "#contact" },
 ];
@@ -231,23 +231,24 @@ test.describe("navigation", () => {
 
     await expect(menuButton).toHaveAttribute("aria-expanded", "true");
 
-    const howIWorkLink = page.getByRole("link", {
-      name: "How I work",
+    const engineeringLink = page.getByRole("link", {
+      name: "Engineering",
       exact: true,
     });
 
-    await expect(howIWorkLink).toBeVisible();
-    await howIWorkLink.click();
+    await expect(engineeringLink).toBeVisible();
+    await engineeringLink.click();
 
-    await expect(page).toHaveURL("/#how-i-work");
+    await expect(page).toHaveURL("/#engineering-work");
     await expect(menuButton).toHaveAttribute("aria-expanded", "false");
 
     const targetPosition = await page.evaluate(() => ({
       headerBottom: document
         .querySelector(".site-header")!
         .getBoundingClientRect().bottom,
-      sectionTop: document.querySelector("#how-i-work")!.getBoundingClientRect()
-        .top,
+      sectionTop: document
+        .querySelector("#engineering-work")!
+        .getBoundingClientRect().top,
     }));
 
     expect(targetPosition.sectionTop).toBeGreaterThanOrEqual(

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -185,6 +185,17 @@ test.describe("navigation", () => {
     }
   });
 
+  test("Experience remains active through the contextual How I work section", async ({
+    page,
+  }) => {
+    await page.goto("/#how-i-work");
+
+    await expect(page.locator("#how-i-work")).toBeInViewport();
+    await expect(
+      page.getByRole("link", { name: "Experience", exact: true }),
+    ).toHaveAttribute("aria-current", "location");
+  });
+
   test("the Kitaka home link returns to the true top of the homepage", async ({
     page,
   }) => {

--- a/tests/routes.spec.ts
+++ b/tests/routes.spec.ts
@@ -17,7 +17,7 @@ const routes = [
     heading: "Writing",
   },
   {
-    name: "testing is information article",
+    name: "release decision article",
     path: "/writing/testing-is-information-not-approval",
     heading: "Are we good to go?",
   },


### PR DESCRIPTION
## Summary

- Reorder the homepage as Experience → How I Work → Engineering Work → Writing → Contact
- Move inspectable engineering evidence ahead of Writing
- Replace How I Work with Engineering in the primary navigation
- Keep Experience active while visitors pass through the contextual How I Work section
- Update navigation coverage and protect the agreed homepage order
- Correct stale test terminology

## Verification

- [x] Navigation and route suites — 111 tests passed
- [x] Desktop, tablet and mobile Playwright projects
- [x] Local browser review

Closes #121